### PR TITLE
Fix #22 - Integrating laidig_validator into gtfs-realtime-validator to validate GTFS feed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,19 @@
             <artifactId>junit</artifactId>
             <version>4.12</version>
         </dependency>
-
+        
+        <!-- LAIDIG-gtfs-validator... json and lib modules -->
+        <dependency>
+            <groupId>com.conveyal</groupId>
+            <artifactId>gtfs-validator-json</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>com.conveyal</groupId>
+            <artifactId>gtfs-validation-lib</artifactId>
+            <version>0.1.3</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -240,6 +252,10 @@
                                 implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                             <mainClass>edu.usf.cutr.gtfsrtvalidator.Main</mainClass>
                         </transformer>
+                        <!-- files overwrite each other and geotools does not function without 
+                        this. http://docs.geotools.org/latest/userguide/faq.html#how-do-i-create-an-executable-jar-for-my-geotools-app -->
+                        <transformer
+                                implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                     </transformers>
                 </configuration>
 

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/GtfsFeedModel.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/GtfsFeedModel.java
@@ -26,6 +26,7 @@ public class GtfsFeedModel {
     private int feedId;
     private long startTime;
     private String feedLocation;
+    private byte[] checksum;
 
     public static String FEEDID = "feedId";
     public static String FEEDURL = "feedUrl";
@@ -53,6 +54,10 @@ public class GtfsFeedModel {
     public long getStartTime() {
         return startTime;
     }
+    
+    public byte[] getChecksum() {
+        return checksum;
+    }
 
     public void setStartTime(long startTime) {
         this.startTime = startTime;
@@ -64,6 +69,10 @@ public class GtfsFeedModel {
 
     public void setFeedLocation(String feedLocation) {
         this.feedLocation = feedLocation;
+    }
+    
+    public void setChecksum(byte[] checksum) {
+        this.checksum = checksum;
     }
 
     @Override

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/db/GTFSDB.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/db/GTFSDB.java
@@ -743,10 +743,11 @@ public class GTFSDB {
             PreparedStatement stmt;
             con.setAutoCommit(false);
 
-            stmt = con.prepareStatement("INSERT INTO GtfsFeed (feedUrl, fileLocation, downloadTimestamp)VALUES (?,?,?)", Statement.RETURN_GENERATED_KEYS);
+            stmt = con.prepareStatement("INSERT INTO GtfsFeed (feedUrl, fileLocation, downloadTimestamp, fileChecksum)VALUES (?,?,?,?)", Statement.RETURN_GENERATED_KEYS);
             stmt.setString(1, gtfsFeed.getGtfsUrl());
             stmt.setString(2, gtfsFeed.getFeedLocation());
             stmt.setLong(3, TimeStampHelper.getCurrentTimestamp());
+            stmt.setBytes(4, gtfsFeed.getChecksum());
 
             stmt.executeUpdate();
 
@@ -782,12 +783,13 @@ public class GTFSDB {
             PreparedStatement stmt;
             con.setAutoCommit(false);
 
-            stmt = con.prepareStatement("UPDATE GtfsFeed SET feedUrl = ?, fileLocation = ?, downloadTimestamp = ? " +
-                    "WHERE feedID = ?");
+            stmt = con.prepareStatement("UPDATE GtfsFeed SET feedUrl = ?, fileLocation = ?, downloadTimestamp = ?, " +
+                    "fileChecksum = ? WHERE feedID = ?");
             stmt.setString(1, gtfsFeed.getGtfsUrl());
             stmt.setString(2, gtfsFeed.getFeedLocation());
             stmt.setLong(3, gtfsFeed.getStartTime());
-            stmt.setInt(4, gtfsFeed.getFeedId());
+            stmt.setBytes(4, gtfsFeed.getChecksum());
+            stmt.setInt(5, gtfsFeed.getFeedId());
 
             stmt.executeUpdate();
 
@@ -828,6 +830,7 @@ public class GTFSDB {
                 gtfsFeed.setFeedId(rs.getInt("feedID"));
                 gtfsFeed.setStartTime(rs.getLong("downloadTimestamp"));
                 gtfsFeed.setFeedLocation(rs.getString("fileLocation"));
+                gtfsFeed.setChecksum(rs.getBytes("fileChecksum"));
             } else {
                 return null;
             }
@@ -871,6 +874,7 @@ public class GTFSDB {
                 gtfsFeed.setFeedId(rs.getInt("feedID"));
                 gtfsFeed.setStartTime(rs.getLong("downloadTimestamp"));
                 gtfsFeed.setFeedLocation(rs.getString("fileLocation"));
+                gtfsFeed.setChecksum(rs.getBytes("fileChecksum"));
             } else {
                 return null;
             }
@@ -912,6 +916,7 @@ public class GTFSDB {
                 gtfsFeed.setFeedId(rs.getInt("feedID"));
                 gtfsFeed.setStartTime(rs.getLong("downloadTimestamp"));
                 gtfsFeed.setFeedLocation(rs.getString("fileLocation"));
+                gtfsFeed.setChecksum(rs.getBytes("fileChecksum"));
 
                 gtfsFeedModelList.add(gtfsFeed);
             }

--- a/src/main/resources/createTables.sql
+++ b/src/main/resources/createTables.sql
@@ -2,7 +2,8 @@ CREATE TABLE IF NOT EXISTS "GtfsFeed" (
   "feedID"            INTEGER PRIMARY KEY AUTOINCREMENT,
   "feedUrl"           TEXT,
   "fileLocation"      TEXT,
-  "downloadTimestamp" INTEGER
+  "downloadTimestamp" INTEGER,
+  "fileChecksum"      BLOB
 );
 
 CREATE TABLE IF NOT EXISTS "GtfsRtFeed" (


### PR DESCRIPTION
This PR depends on laidig_validator jar version 0.1.1.  For now, this laidig_validator version is cloned locally and installed, for this PR to work. 

Also creates and stores MD5 hash for the input static GTFS feed, so that the same GTFS feed is not validated again.

Fix #22 