### PR TITLE
Remove Travis script to install laidig/gtfs-validator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,2 @@
 language: java
 jdk: oraclejdk8
-
-# TODO - Figure out where to host the Laidig fork artifacts for gtfs-validator
-before_install: 
-  - git clone https://github.com/laidig/gtfs-validator.git
-  - cd gtfs-validator
-  - mvn install -DskipTests
-  - cd ..


### PR DESCRIPTION
**Summary:**

We don't need to manually install the laidig/gtfs-validator for dependencies on Travis - following https://github.com/CUTR-at-USF/gtfs-realtime-validator/commit/dae76a4059dcfa4e47af75274ff2fac13f000cda, we're managing all build dependencies via pure Maven.

**Expected behavior:** 

Travis should now pass without installing laidig/gtfs-validator artifacts