### PR TITLE
Fix #62 - Can't load GTFS data from a URL

### DIFF
--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsFeed.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsFeed.java
@@ -123,7 +123,10 @@ public class GtfsFeed {
                             + "WHERE gtfsUrl = '"+gtfsFeedUrl+"'").uniqueResult();
         GTFSDB.commitAndCloseSession(session);
         ObjectMapper mapper = new ObjectMapper();
-        downloadGtfsFeed(saveFilePath, connection);
+        Response.Status response = downloadGtfsFeed(saveFilePath, connection);
+        if(response == null)
+            return generateError("Download Failed", "Downloading static GTFS feed from provided Url failed", Response.Status.BAD_REQUEST);
+
         System.out.println("GTFS File Downloaded Successfully");
         //TODO: Move to one method
         if (gtfsFeed == null) {
@@ -221,8 +224,9 @@ public class GtfsFeed {
         } else {
             //Extracts file name from header field
             int index = disposition.indexOf("filename=");
+            int filenameLastIndex = disposition.indexOf("\"", index+10);
             if (index > 0) {
-                fileName = disposition.substring(index + 10, disposition.length() - 1);
+                fileName = disposition.substring(index + 10, filenameLastIndex);
             }
         }
 
@@ -296,7 +300,7 @@ public class GtfsFeed {
         return store;
     }
 
-    private void downloadGtfsFeed(String saveFilePath, HttpURLConnection connection) {
+    private Response.Status downloadGtfsFeed(String saveFilePath, HttpURLConnection connection) {
         try {
             // opens input stream from the HTTP connection
             InputStream inputStream = connection.getInputStream();
@@ -314,6 +318,8 @@ public class GtfsFeed {
             inputStream.close();
         } catch (IOException ex) {
             System.out.println("Downloading GTFS Feed Failed");
+            return null;
         }
+        return Response.Status.OK;
     }
 }


### PR DESCRIPTION
**Summary:**

Modified to correctly read the file name from given static Gtfs URL.

But, you will see an issue https://github.com/conveyal/gtfs-validator/issues/28, if your static Gtfs file does not have the optional file `calendar_dates.txt`. The conveyal code is missing to check null values for it. You can see the description about the issue mentioned in the above URL. The fix for the issue is created in PR https://github.com/conveyal/gtfs-validator/pull/29. 
Once the PR in conveyal project is fixed, you can expect the application to work as mentioned in the below **Expected behavior** section.

**Expected behavior:** 

*  Try to run the application if you installed locally using, http://localhost:8080
*  Use different static Gtfs data links. For example, you may use below provided links to test.
https://drive.google.com/uc?export=download&id=0BzTMCDngWQJ4eElfWV9tZE1vRUU
https://dl.dropboxusercontent.com/u/107527881/final_dt2.zip
http://www.mbta.com/uploadedfiles/MBTA_GTFS.zip
http://gohart.org/google/google_transit.zip
*  For all these feed links provided, the application should download these files successfully and start running.


