### PR TITLE
Fix #76 (hopefully) - Overhaul logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,18 +106,6 @@
             </exclusions>
         </dependency>
 
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.24</version>
-        </dependency>
-
         <!-- protobuf-java-fromat to format protobuf message to json-->
         <dependency>
             <groupId>com.googlecode.protobuf-java-format</groupId>

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/Main.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/Main.java
@@ -24,8 +24,11 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.slf4j.LoggerFactory;
 
 public class Main {
+    private static final org.slf4j.Logger _log = LoggerFactory.getLogger(Main.class);
+
     static String BASE_RESOURCE = "./target/classes/webroot";
 
     public static void main(String[] args) throws InterruptedException{
@@ -49,6 +52,7 @@ public class Main {
 
         try {
             server.start();
+            _log.info("Go to http://localhost:8080 in your browser");
             server.join();
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/GtfsRtFeedIterationString.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/GtfsRtFeedIterationString.java
@@ -84,7 +84,6 @@ public class GtfsRtFeedIterationString {
             GtfsRealtime.FeedMessage feedMessage = GtfsRealtime.FeedMessage.parseFrom(feedprotobuf);
             s = JsonFormat.printToString(feedMessage);
             s.replace('\\', ' ');
-            System.out.println(s);
         } catch (InvalidProtocolBufferException e) {
             e.printStackTrace();
         }

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsRtFeed.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsRtFeed.java
@@ -17,8 +17,6 @@
 
 package edu.usf.cutr.gtfsrtvalidator.api.resource;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.transit.realtime.GtfsRealtime;
 import edu.usf.cutr.gtfsrtvalidator.api.model.*;
 import edu.usf.cutr.gtfsrtvalidator.api.model.combined.CombinedIterationMessageModel;
@@ -26,6 +24,8 @@ import edu.usf.cutr.gtfsrtvalidator.api.model.combined.CombinedMessageOccurrence
 import edu.usf.cutr.gtfsrtvalidator.background.BackgroundTask;
 import edu.usf.cutr.gtfsrtvalidator.db.GTFSDB;
 import edu.usf.cutr.gtfsrtvalidator.helper.TimeStampHelper;
+import org.hibernate.Session;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.GenericEntity;
@@ -43,10 +43,11 @@ import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import org.hibernate.Session;
 
 @Path("/gtfs-rt-feed")
 public class GtfsRtFeed {
+
+    private static final org.slf4j.Logger _log = LoggerFactory.getLogger(GtfsRtFeed.class);
 
     private static final int INVALID_FEED = 0;
     private static final int VALID_FEED = 1;
@@ -195,7 +196,6 @@ public class GtfsRtFeed {
     private int checkFeedType(String FeedURL) {
         GtfsRealtime.FeedMessage feed;
         try {
-            System.out.println(FeedURL);
             URI FeedURI = new URI(FeedURL);
             URL url = FeedURI.toURL();
             feed = GtfsRealtime.FeedMessage.parseFrom(url.openStream());
@@ -203,6 +203,7 @@ public class GtfsRtFeed {
             return INVALID_FEED;
         }
         if (feed.hasHeader()) {
+            _log.info(String.format("%s is a valid GTFS-realtime feed", FeedURL));
             return VALID_FEED;
         }
         return INVALID_FEED;

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/background/BackgroundTask.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/background/BackgroundTask.java
@@ -31,6 +31,7 @@ import edu.usf.cutr.gtfsrtvalidator.validation.interfaces.FeedEntityValidator;
 import org.apache.commons.io.IOUtils;
 import org.hibernate.Session;
 import org.onebusaway.gtfs.impl.GtfsDaoImpl;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -42,6 +43,9 @@ import java.util.List;
 import java.util.Map;
 
 public class BackgroundTask implements Runnable {
+
+    private static final org.slf4j.Logger _log = LoggerFactory.getLogger(BackgroundTask.class);
+
     //Entity list kept under the gtfsRtFeed id.
     //Used to check errors with different feeds for the same transit agency.
 
@@ -76,7 +80,7 @@ public class BackgroundTask implements Runnable {
             try {
                 gtfsRtFeedUrl = new URL(currentFeed.getGtfsUrl());
             } catch (MalformedURLException e) {
-                System.out.println("Malformed Url: " + currentFeed.getGtfsUrl());
+                _log.error("Malformed Url: " + currentFeed.getGtfsUrl(), e);
                 e.printStackTrace();
                 return;
             }
@@ -94,8 +98,7 @@ public class BackgroundTask implements Runnable {
                 session.save(feedIteration);
                 GTFSDB.commitAndCloseSession(session);                
             } catch (Exception e) {
-                System.out.println("The URL: " + gtfsRtFeedUrl + " does not contain valid Gtfs-Rt data");
-                //e.printStackTrace();
+                _log.error("The URL '" + gtfsRtFeedUrl + "' does not contain valid Gtfs-Rt data", e);
                 return;
             }
             //---------------------------------------------------------------------------------------

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/db/GTFSDB.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/db/GTFSDB.java
@@ -17,21 +17,27 @@
 
 package edu.usf.cutr.gtfsrtvalidator.db;
 
-import edu.usf.cutr.gtfsrtvalidator.api.model.*;
+import edu.usf.cutr.gtfsrtvalidator.api.model.ValidationRule;
 import edu.usf.cutr.gtfsrtvalidator.hibernate.HibernateUtil;
 import edu.usf.cutr.gtfsrtvalidator.validation.ValidationRules;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
-import org.hibernate.Session;
-import org.hibernate.Transaction;
 
 public class GTFSDB {
+
+    private static final Logger _log = LoggerFactory.getLogger(GTFSDB.class);
 
     public static void InitializeDB() {
         Statement stmt;
@@ -73,7 +79,6 @@ public class GTFSDB {
                     try {
                         Object value = field.get(rule);
                         rule = (ValidationRule)value;
-                        System.out.println(rule.getErrorDescription());
                         ValidationRule validationRule = (ValidationRule) session.createQuery("FROM ValidationRule WHERE errorId = "
                                 + "'" + rule.getErrorId() + "'").uniqueResult();
                         if(validationRule == null) {
@@ -95,7 +100,7 @@ public class GTFSDB {
             ex.printStackTrace();
         }
 
-        System.out.println("Table initialized successfully");
+        _log.info("Table initialized successfully");
     }
     public static Session InitSessionBeginTrans() {
         Session session = null;

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/entity/StopTimeSequanceValidator.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/entity/StopTimeSequanceValidator.java
@@ -25,6 +25,7 @@ import edu.usf.cutr.gtfsrtvalidator.helper.ErrorListHelperModel;
 import edu.usf.cutr.gtfsrtvalidator.validation.ValidationRules;
 import edu.usf.cutr.gtfsrtvalidator.validation.interfaces.FeedEntityValidator;
 import org.onebusaway.gtfs.impl.GtfsDaoImpl;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,6 +35,9 @@ import java.util.List;
  * Description: stop_time_updates for a given trip_id must be sorted by increasing stop_sequence
  */
 public class StopTimeSequanceValidator implements FeedEntityValidator {
+
+    private static final org.slf4j.Logger _log = LoggerFactory.getLogger(StopTimeSequanceValidator.class);
+
     @Override
     public ErrorListHelperModel validate(GtfsDaoImpl gtfsData, GtfsRealtime.FeedMessage feedMessage) {
         List<GtfsRealtime.FeedEntity> entityList = feedMessage.getEntityList();
@@ -60,7 +64,7 @@ public class StopTimeSequanceValidator implements FeedEntityValidator {
 
             boolean sorted = Ordering.natural().isOrdered(stopSequenceList);
             if (!sorted) {
-                //System.out.println("StopSequenceList is not in order");
+                _log.debug("StopSequenceList is not in order");
                 String feedId = tripUpdateEntity.getId();
                 OccurrenceModel occurrenceModel = new OccurrenceModel("$.entity[?(@.id == \"" + feedId + "\")]", stopSequenceList.toString());
                 errorOccurrenceList.add(occurrenceModel);

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/entity/TimestampValidation.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/entity/TimestampValidation.java
@@ -23,11 +23,14 @@ import edu.usf.cutr.gtfsrtvalidator.api.model.OccurrenceModel;
 import edu.usf.cutr.gtfsrtvalidator.helper.ErrorListHelperModel;
 import edu.usf.cutr.gtfsrtvalidator.validation.interfaces.FeedEntityValidator;
 import org.onebusaway.gtfs.impl.GtfsDaoImpl;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class TimestampValidation implements FeedEntityValidator{
+
+    private static final org.slf4j.Logger _log = LoggerFactory.getLogger(TimestampValidation.class);
 
     @Override
     public ErrorListHelperModel validate(GtfsDaoImpl gtfsData, GtfsRealtime.FeedMessage feedMessage) {
@@ -37,7 +40,7 @@ public class TimestampValidation implements FeedEntityValidator{
         
         long headerTimestamp = feedMessage.getHeader().getTimestamp();
         if (headerTimestamp == 0) {
-            System.out.println("Timestamp not present in FeedHeader");
+            _log.debug("Timestamp not present in FeedHeader");
             errorOccurrence = new OccurrenceModel("$.header.timestamp not populated", String.valueOf(headerTimestamp));
             errorOccurrenceList.add(errorOccurrence);
         }
@@ -45,12 +48,12 @@ public class TimestampValidation implements FeedEntityValidator{
             long tripupdateTimestamp = entity.getTripUpdate().getTimestamp();
             long vehicleTimestamp = entity.getVehicle().getTimestamp();
             if (tripupdateTimestamp == 0) {
-                System.out.println("Timestamp not present in TripUpdate");
+                _log.debug("Timestamp not present in TripUpdate");
                 errorOccurrence = new OccurrenceModel("$.entity.*.trip_update.timestamp not populated", String.valueOf(tripupdateTimestamp));
                 errorOccurrenceList.add(errorOccurrence);
             }
             if (vehicleTimestamp == 0) {
-                System.out.println("Timestamp not present in VehiclePosition");
+                _log.debug("Timestamp not present in VehiclePosition");
                 errorOccurrence = new OccurrenceModel("$.entity.*.vehicle_position.timestamp not populated", String.valueOf(vehicleTimestamp));
                 errorOccurrenceList.add(errorOccurrence);
             }

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/entity/VehicleIdValidator.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/entity/VehicleIdValidator.java
@@ -24,6 +24,7 @@ import edu.usf.cutr.gtfsrtvalidator.helper.ErrorListHelperModel;
 import edu.usf.cutr.gtfsrtvalidator.validation.ValidationRules;
 import edu.usf.cutr.gtfsrtvalidator.validation.interfaces.FeedEntityValidator;
 import org.onebusaway.gtfs.impl.GtfsDaoImpl;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +36,8 @@ import java.util.List;
  */
 
 public class VehicleIdValidator implements FeedEntityValidator {
+
+    private static final org.slf4j.Logger _log = LoggerFactory.getLogger(VehicleIdValidator.class);
 
     @Override
     public ErrorListHelperModel validate(GtfsDaoImpl gtfsData, GtfsRealtime.FeedMessage feedMessage) {
@@ -52,7 +55,7 @@ public class VehicleIdValidator implements FeedEntityValidator {
                 if (tripUpdate.getVehicle().getId() == null) {
                     OccurrenceModel errorOccurrence = new OccurrenceModel("$.entity["+ entityId +"].trip_update", null);
                     errorOccurrenceList.add(errorOccurrence);
-                    System.out.println(ValidationRules.W002.getErrorDescription());
+                    _log.debug(ValidationRules.W002.getErrorDescription());
                 }
             }
             entityId++;

--- a/src/main/resources/jetty-logging.properties
+++ b/src/main/resources/jetty-logging.properties
@@ -1,1 +1,1 @@
-org.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.JavaUtilLog
+org.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.Slf4jLog

--- a/src/main/resources/logging.properties
+++ b/src/main/resources/logging.properties
@@ -1,4 +1,5 @@
 handlers = org.eclipse.jetty.demo.SystemOutHandler
 .level = INFO
-#org.eclipse.jetty.level = FINE 
-#org.apache.level = FINEST
+# FIXME - Changing the logging level below doesn't seem to have any effect
+org.eclipse.jetty.LEVEL=WARN
+org.eclipse.jetty.server.Server.level=WARN


### PR DESCRIPTION
**Summary:**

* Remove existing dependencies on slf4j in pom.xml, as they aren't being used and may finally fix https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/76
* Change System.out.println() to use a Logger instead
* Cleanup output that doesn't provide useful feedback
* Update logging properties to point to slf4j instead (although  I'm not currently convinced that slf4j is currently being used to output the Logger statements)

FIXME (in the future):
* Filter of log levels still doesn't seem to work
* Not sure if slf4j is actually being used for the Logger

**Expected behavior:** 

Start the project from within IntelliJ or command line, and see output on the console (and slf4j error should no longer appear)

@mohangandhiGH Can you please review and make sure I'm not breaking anything?
