### PR TITLE
Fix #82 - When creating combined GTFS-rt feed set a header

### DIFF
--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/background/BackgroundTask.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/background/BackgroundTask.java
@@ -110,13 +110,20 @@ public class BackgroundTask implements Runnable {
 
             List<GtfsRealtime.FeedEntity> allEntitiesArrayList = new ArrayList<>();
 
+            GtfsRealtime.FeedHeader header = null;
+
             for (Map.Entry<Integer, GtfsRealtime.FeedMessage> allFeeds : feedEntityInstance.entrySet()) {
                 int key = allFeeds.getKey();
                 GtfsRealtime.FeedMessage message = feedEntityInstance.get(key);
+                if (header == null) {
+                    // Save one header to use in our combined feed below
+                    header = feedEntityInstance.get(key).getHeader();
+                }
                 allEntitiesArrayList.addAll(message.getEntityList());
             }
 
             GtfsRealtime.FeedMessage.Builder feedMessageBuilder = GtfsRealtime.FeedMessage.newBuilder();
+            feedMessageBuilder.setHeader(header);
             feedMessageBuilder.addAllEntity(allEntitiesArrayList);
 
             GtfsRealtime.FeedMessage combinedFeed = feedMessageBuilder.build();


### PR DESCRIPTION
**Summary:**

This fixes an error that I'm seeing after making the changes in https://github.com/CUTR-at-USF/gtfs-realtime-validator/pull/81.

**Expected behavior:** 

After this patch, an error with creating a combined GTFS-rt feed should no longer show up when running https://github.com/CUTR-at-USF/gtfs-realtime-validator/pull/81.  See https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/82 for details.

@mohangandhiGH Can you please review?