### PR TITLE
Fix #89 - Handle HTTP 301 redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Following are the requirements to get the project up and running.
 * JDK installed on the system 
 * Maven installed on the system 
 * (optional) git installed on the system to clone the repository
+* [Java Cryptography Extension (JCE)](http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html) - If you're downloading GTFS or GTFS-rt from secure HTTPS URLs, you may need to install the JCE Extension.  You will need to replace the `US_export_policy.jar` and `local_policy.jar` files in your JVM `/security` directory, such as `C:\Program Files\Java\jdk1.8.0_73\jre\lib\security`, with the JAR files in the JCE Extension download. 
 
 ### 1. Download the code 
 

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsFeed.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsFeed.java
@@ -32,6 +32,7 @@ import org.onebusaway.gtfs.impl.GtfsDaoImpl;
 import org.onebusaway.gtfs.serialization.GtfsReader;
 import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.SSLHandshakeException;
 import javax.ws.rs.*;
 import javax.ws.rs.core.GenericEntity;
 import javax.ws.rs.core.MediaType;
@@ -316,11 +317,18 @@ public class GtfsFeed {
             // Check for HTTP 301 redirect
             String redirect = connection.getHeaderField("Location");
             if (redirect != null) {
+                _log.warn("Redirecting to " + redirect);
                 connection = (HttpURLConnection) new URL(redirect).openConnection();
             }
 
-            // opens input stream from the HTTP connection
-            InputStream inputStream = connection.getInputStream();
+            // Opens input stream from the HTTP(S) connection
+            InputStream inputStream;
+            try {
+                inputStream = connection.getInputStream();
+            } catch (SSLHandshakeException sslEx) {
+                _log.error("SSL handshake failed.  Try installing the JCE Extension - see https://github.com/CUTR-at-USF/gtfs-realtime-validator#prerequisites", sslEx);
+                return null;
+            }
 
             // opens an output stream to save into file
             FileOutputStream outputStream = new FileOutputStream(saveFilePath);

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsFeed.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsFeed.java
@@ -313,6 +313,12 @@ public class GtfsFeed {
 
     private Response.Status downloadGtfsFeed(String saveFilePath, HttpURLConnection connection) {
         try {
+            // Check for HTTP 301 redirect
+            String redirect = connection.getHeaderField("Location");
+            if (redirect != null) {
+                connection = (HttpURLConnection) new URL(redirect).openConnection();
+            }
+
             // opens input stream from the HTTP connection
             InputStream inputStream = connection.getInputStream();
 


### PR DESCRIPTION
- [x] Fix SSL handshake for redirects to HTTPS - see https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/89#issuecomment-289845276.
- [x] Add logging and exception handling for SSL handshake issues
- [x] Add JCE Extension documentation to README