### PR TITLE
Fix #92 - Don't save duplicate PB feed files to local database

### DIFF
--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/GtfsRtFeedIterationModel.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/GtfsRtFeedIterationModel.java
@@ -28,11 +28,11 @@ public class GtfsRtFeedIterationModel implements Serializable {
 
     public GtfsRtFeedIterationModel() {}
 
-    public GtfsRtFeedIterationModel(long timeStamp, byte[] feedprotobuf, GtfsRtFeedModel gtfsRtFeedModel, boolean isUniqueFeed) {
+    public GtfsRtFeedIterationModel(long timeStamp, byte[] feedprotobuf, GtfsRtFeedModel gtfsRtFeedModel, byte[] feedHash) {
         this.timeStamp = timeStamp;
         this.feedprotobuf = feedprotobuf;
         this.gtfsRtFeedModel = gtfsRtFeedModel;
-        this.isUniqueFeed = isUniqueFeed;
+        this.feedHash = feedHash;
     }
 
     @Id
@@ -47,8 +47,8 @@ public class GtfsRtFeedIterationModel implements Serializable {
     @ManyToOne
     @JoinColumn(name = "rtFeedID")
     private GtfsRtFeedModel gtfsRtFeedModel;
-    @Column(name = "isUniqueFeed", columnDefinition = "boolean default false", nullable = false)
-    private boolean isUniqueFeed;
+    @Column(name = "feedHash")
+    private byte[] feedHash;
 
     public GtfsRtFeedModel getGtfsRtFeedModel() {
         return gtfsRtFeedModel;
@@ -82,11 +82,11 @@ public class GtfsRtFeedIterationModel implements Serializable {
         this.feedprotobuf = feedprotobuf;
     }
 
-    public boolean isUniqueFeed() {
-        return isUniqueFeed;
+    public byte[] getFeedHash() {
+        return feedHash;
     }
 
-    public void setUniqueFeed(boolean uniqueFeed) {
-        isUniqueFeed = uniqueFeed;
+    public void setFeedHash(byte[] feedHash) {
+        this.feedHash = feedHash;
     }
 }

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/ViewFeedUniqueResponseCount.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/ViewFeedUniqueResponseCount.java
@@ -26,10 +26,10 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement
 @Entity
 @NamedNativeQuery(name = "feedUniqueResponseCount",
-        query = "SELECT count(isUniqueFeed) AS uniqueFeedCount " +
+        query = "SELECT count(*) AS uniqueFeedCount " +
                 "FROM GtfsRtFeedIteration " +
                 "WHERE (rtFeedID = ? " +
-                    "AND isUniqueFeed = 1)",
+                    "AND feedProtobuf IS NOT NULL)",
         resultClass = ViewFeedUniqueResponseCount.class)
 public class ViewFeedUniqueResponseCount {
 


### PR DESCRIPTION
**Summary:**

Now we store PB files to the database, only if it's not already stored in the last iteration of same PB file.
Fixes #92. 

**Expected behavior:** 

Duplicate PB files are not stored in the database.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "Fix #issue - short description of fix and changes"
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
