### PR TITLE
Fix #96 - Only log validation warnings/errors for unique responses

### DIFF
--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/background/BackgroundTask.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/background/BackgroundTask.java
@@ -121,6 +121,10 @@ public class BackgroundTask implements Runnable {
                 }
                 session.save(feedIteration);
                 GTFSDB.commitAndCloseSession(session);
+
+                if (!isUniqueFeed) {
+                    return;
+                }
             } catch (Exception e) {
                 _log.error("The URL '" + gtfsRtFeedUrl + "' does not contain valid Gtfs-Rt data", e);
                 return;


### PR DESCRIPTION
**Summary:**

Log validation warnings/errors for unique responses. Fixes #96. 

**Expected behavior:** 

Only unique response PB feeds are validated and warnings/errors are stored in database for those unique feeds.
 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "Fix #issue - short description of fix and changes"
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
