### PR TITLE
Fix #102 - Add new rule E012 - "No entity timestamps can be greater than header"

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -18,6 +18,7 @@
 | [E003](#E003) | `trip_id` mismatch in GTFS-rt and GTFS
 | [E010](#E010) | `location_type` not `0` in `stops.txt`
 | [E011](#E011) | `location_type` not `0` in GTFS-rt
+| [E012](#E012) | Header timestamp should be greater than or equal to all other timestamps
 
 # Warnings
 
@@ -70,3 +71,9 @@ If location_type is used in `stops.txt`, all stops referenced in `stop_times.txt
 ### E011 - `location_type` not `0` in GTFS-rt
 
 All `stop_ids` referenced in GTFS-rt feeds must have the `location_type` = `0`
+
+<a name="E012"/>
+
+### E012 - Header timestamp should be greater than or equal to all other timestamps
+
+No timestamps for individual entities (TripUpdate, VehiclePosition, Alerts) in the feeds should be greater than the header timestamp.

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/background/BackgroundTask.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/background/BackgroundTask.java
@@ -166,7 +166,7 @@ public class BackgroundTask implements Runnable {
 
             //region warnings
             //---------------------------------------------------------------------------------------
-            //w001
+            //w001 and e012
             FeedEntityValidator validateTimestamp = new TimestampValidation();
             validateEntity(feedMessage, gtfsData, feedIteration, validateTimestamp);
             //---------------------------------------------------------------------------------------
@@ -198,14 +198,15 @@ public class BackgroundTask implements Runnable {
     }
 
     private void validateEntity(GtfsRealtime.FeedMessage feedMessage, GtfsDaoImpl gtfsData, GtfsRtFeedIterationModel feedIteration, FeedEntityValidator feedEntityValidator) {
-        ErrorListHelperModel errorList = feedEntityValidator.validate(gtfsData, feedMessage);
+        List<ErrorListHelperModel> errorLists = feedEntityValidator.validate(gtfsData, feedMessage);
 
-        if (errorList != null && !errorList.getOccurrenceList().isEmpty()) {
-            //Set iteration Id
-            errorList.getErrorMessage().setGtfsRtFeedIterationModel(feedIteration);
-            //Save the captured errors to the database
-            DBHelper.saveError(errorList);
+        for (ErrorListHelperModel errorList : errorLists) {
+            if (errorList != null && !errorList.getOccurrenceList().isEmpty()) {
+                //Set iteration Id
+                errorList.getErrorMessage().setGtfsRtFeedIterationModel(feedIteration);
+                //Save the captured errors to the database
+                DBHelper.saveError(errorList);
+            }
         }
     }
-
 }

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/ValidationRules.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/ValidationRules.java
@@ -71,4 +71,7 @@ public class ValidationRules {
             "All stop_ids referenced in GTFS-rt feeds must have the location_type = 0");
     //---------------------------------------------------------------------------------------
     //endregion
+
+    public static final ValidationRule E012 = new ValidationRule("e012", "ERROR", "Header timestamp should be greater than or equal to all other timestamps",
+            "No timestamps for individual entities (TripUpdate, VehiclePosition) in the feeds should be greater than the header timestamp");
 }

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/entity/CheckTripId.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/entity/CheckTripId.java
@@ -27,6 +27,7 @@ import org.onebusaway.gtfs.impl.GtfsDaoImpl;
 import org.onebusaway.gtfs.model.Trip;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -36,7 +37,7 @@ import java.util.List;
  */
 public class CheckTripId implements FeedEntityValidator {
     @Override
-    public ErrorListHelperModel validate(GtfsDaoImpl gtfsData, GtfsRealtime.FeedMessage feedMessage) {
+    public List<ErrorListHelperModel> validate(GtfsDaoImpl gtfsData, GtfsRealtime.FeedMessage feedMessage) {
         Collection<Trip> gtfsTripList = gtfsData.getAllTrips();
 
         MessageLogModel messageLogModel = new MessageLogModel(ValidationRules.E003);
@@ -59,7 +60,6 @@ public class CheckTripId implements FeedEntityValidator {
                 }
             }
         }
-
-        return  new ErrorListHelperModel(messageLogModel, errorOccurrenceList);
+        return Arrays.asList(new ErrorListHelperModel(messageLogModel, errorOccurrenceList));
     }
 }

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/entity/LocationTypeReferenceValidator.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/entity/LocationTypeReferenceValidator.java
@@ -34,7 +34,7 @@ import java.util.*;
  */
 public class LocationTypeReferenceValidator implements FeedEntityValidator {
     @Override
-    public ErrorListHelperModel validate(GtfsDaoImpl gtfsData, GtfsRealtime.FeedMessage feedMessage) {
+    public List<ErrorListHelperModel> validate(GtfsDaoImpl gtfsData, GtfsRealtime.FeedMessage feedMessage) {
 
         MessageLogModel messageLogModel = new MessageLogModel(ValidationRules.E011);
         List<OccurrenceModel> errorOccurrenceList = new ArrayList<>();
@@ -82,6 +82,6 @@ public class LocationTypeReferenceValidator implements FeedEntityValidator {
                 }
             }
         }
-        return new ErrorListHelperModel(messageLogModel, errorOccurrenceList);
+        return Arrays.asList(new ErrorListHelperModel(messageLogModel, errorOccurrenceList));
     }
 }

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/entity/StopTimeSequanceValidator.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/entity/StopTimeSequanceValidator.java
@@ -28,6 +28,7 @@ import org.onebusaway.gtfs.impl.GtfsDaoImpl;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -39,7 +40,7 @@ public class StopTimeSequanceValidator implements FeedEntityValidator {
     private static final org.slf4j.Logger _log = LoggerFactory.getLogger(StopTimeSequanceValidator.class);
 
     @Override
-    public ErrorListHelperModel validate(GtfsDaoImpl gtfsData, GtfsRealtime.FeedMessage feedMessage) {
+    public List<ErrorListHelperModel> validate(GtfsDaoImpl gtfsData, GtfsRealtime.FeedMessage feedMessage) {
         List<GtfsRealtime.FeedEntity> entityList = feedMessage.getEntityList();
 
         MessageLogModel messageLogModel = new MessageLogModel(ValidationRules.E002);
@@ -71,10 +72,9 @@ public class StopTimeSequanceValidator implements FeedEntityValidator {
             }
         }
 
-        if(!errorOccurrenceList.isEmpty()){
-            return  new ErrorListHelperModel(messageLogModel, errorOccurrenceList);
+        if (!errorOccurrenceList.isEmpty()) {
+            return Arrays.asList(new ErrorListHelperModel(messageLogModel, errorOccurrenceList));
         }
-
         return null;
     }
 }

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/entity/VehicleIdValidator.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/entity/VehicleIdValidator.java
@@ -28,6 +28,7 @@ import org.onebusaway.gtfs.impl.GtfsDaoImpl;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 
@@ -41,7 +42,7 @@ public class VehicleIdValidator implements FeedEntityValidator {
     private static final org.slf4j.Logger _log = LoggerFactory.getLogger(VehicleIdValidator.class);
 
     @Override
-    public ErrorListHelperModel validate(GtfsDaoImpl gtfsData, GtfsRealtime.FeedMessage feedMessage) {
+    public List<ErrorListHelperModel> validate(GtfsDaoImpl gtfsData, GtfsRealtime.FeedMessage feedMessage) {
         List<GtfsRealtime.FeedEntity> entityList = feedMessage.getEntityList();
         int entityId = 0;
 
@@ -62,8 +63,8 @@ public class VehicleIdValidator implements FeedEntityValidator {
             entityId++;
         }
 
-        if(!errorOccurrenceList.isEmpty()){
-            return  new ErrorListHelperModel(messageLogModel, errorOccurrenceList);
+        if (!errorOccurrenceList.isEmpty()) {
+            return Arrays.asList(new ErrorListHelperModel(messageLogModel, errorOccurrenceList));
         }
         return null;
     }

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/entity/combined/VehicleTripDescriptorValidator.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/entity/combined/VehicleTripDescriptorValidator.java
@@ -26,6 +26,7 @@ import edu.usf.cutr.gtfsrtvalidator.validation.interfaces.FeedEntityValidator;
 import org.onebusaway.gtfs.impl.GtfsDaoImpl;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -36,7 +37,7 @@ public class VehicleTripDescriptorValidator implements FeedEntityValidator {
      * Description: If both vehicle positions and trip updates are provided, VehicleDescriptor or TripDescriptor values should match between the two feeds.
      */
     @Override
-    public ErrorListHelperModel validate(GtfsDaoImpl gtfsData, GtfsRealtime.FeedMessage feedMessage) {
+    public List<ErrorListHelperModel> validate(GtfsDaoImpl gtfsData, GtfsRealtime.FeedMessage feedMessage) {
 
         List<GtfsRealtime.TripUpdate> tripUpdates = new ArrayList<>();
         List<GtfsRealtime.VehiclePosition> vehiclePositions = new ArrayList<>();
@@ -96,9 +97,6 @@ public class VehicleTripDescriptorValidator implements FeedEntityValidator {
                 }
             }
         }
-
-        return new ErrorListHelperModel(messageLogModel, errorOccurrenceList);
+        return Arrays.asList(new ErrorListHelperModel(messageLogModel, errorOccurrenceList));
     }
-
-
 }

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/gtfs/StopLocationTypeValidator.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/gtfs/StopLocationTypeValidator.java
@@ -27,6 +27,7 @@ import org.onebusaway.gtfs.model.Stop;
 import org.onebusaway.gtfs.model.StopTime;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -36,7 +37,7 @@ import java.util.List;
  */
 public class StopLocationTypeValidator implements GtfsFeedValidator {
     @Override
-    public ErrorListHelperModel validate(GtfsDaoImpl gtfsData) {
+    public List<ErrorListHelperModel> validate(GtfsDaoImpl gtfsData) {
         MessageLogModel messageLogModel = new MessageLogModel(ValidationRules.E010);
         List<OccurrenceModel> errorOccurrenceList = new ArrayList<>();
 
@@ -57,7 +58,6 @@ public class StopLocationTypeValidator implements GtfsFeedValidator {
                 }
             }
         }
-
-        return new ErrorListHelperModel(messageLogModel, errorOccurrenceList);
+        return Arrays.asList(new ErrorListHelperModel(messageLogModel, errorOccurrenceList));
     }
 }

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/interfaces/FeedEntityValidator.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/interfaces/FeedEntityValidator.java
@@ -21,6 +21,8 @@ import com.google.transit.realtime.GtfsRealtime;
 import edu.usf.cutr.gtfsrtvalidator.helper.ErrorListHelperModel;
 import org.onebusaway.gtfs.impl.GtfsDaoImpl;
 
+import java.util.List;
+
 public interface FeedEntityValidator {
-    ErrorListHelperModel validate(GtfsDaoImpl gtfsData, GtfsRealtime.FeedMessage feedMessage);
+    List<ErrorListHelperModel> validate(GtfsDaoImpl gtfsData, GtfsRealtime.FeedMessage feedMessage);
 }

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/interfaces/GtfsFeedValidator.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/interfaces/GtfsFeedValidator.java
@@ -20,6 +20,8 @@ package edu.usf.cutr.gtfsrtvalidator.validation.interfaces;
 import edu.usf.cutr.gtfsrtvalidator.helper.ErrorListHelperModel;
 import org.onebusaway.gtfs.impl.GtfsDaoImpl;
 
+import java.util.List;
+
 public interface GtfsFeedValidator {
-    ErrorListHelperModel validate(GtfsDaoImpl gtfsData);
+    List<ErrorListHelperModel> validate(GtfsDaoImpl gtfsData);
 }

--- a/src/test/java/edu/usf/cutr/gtfsrtvalidator/FeedMessageTest.java
+++ b/src/test/java/edu/usf/cutr/gtfsrtvalidator/FeedMessageTest.java
@@ -26,6 +26,8 @@ import org.onebusaway.gtfs.serialization.GtfsReader;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 
 public class FeedMessageTest extends TestCase {
@@ -38,8 +40,8 @@ public class FeedMessageTest extends TestCase {
     
     FeedHeaderTest feedHeaderTest;
     FeedEntityTest feedEntityTest;
-    
-    public ErrorListHelperModel errors;
+
+    public List<ErrorListHelperModel> errors;
     
     public GtfsRealtime.FeedMessage.Builder feedMessageBuilder;
     public GtfsRealtime.FeedEntity.Builder feedEntityBuilder;
@@ -50,7 +52,7 @@ public class FeedMessageTest extends TestCase {
     public GtfsRealtime.Alert.Builder alertBuilder;
         
     public FeedMessageTest() throws IOException {
-        errors = new ErrorListHelperModel();
+        errors = Arrays.asList(new ErrorListHelperModel());
 
         feedMessageBuilder = GtfsRealtime.FeedMessage.newBuilder();
         feedEntityBuilder = GtfsRealtime.FeedEntity.newBuilder();

--- a/src/test/java/edu/usf/cutr/gtfsrtvalidator/test/feeds/TripUpdateFeedTest.java
+++ b/src/test/java/edu/usf/cutr/gtfsrtvalidator/test/feeds/TripUpdateFeedTest.java
@@ -18,6 +18,7 @@ package edu.usf.cutr.gtfsrtvalidator.test.feeds;
 
 import com.google.transit.realtime.GtfsRealtime;
 import edu.usf.cutr.gtfsrtvalidator.FeedMessageTest;
+import edu.usf.cutr.gtfsrtvalidator.helper.ErrorListHelperModel;
 import edu.usf.cutr.gtfsrtvalidator.validation.entity.CheckTripId;
 import edu.usf.cutr.gtfsrtvalidator.validation.entity.StopTimeSequanceValidator;
 import edu.usf.cutr.gtfsrtvalidator.validation.entity.VehicleIdValidator;
@@ -49,7 +50,9 @@ public class TripUpdateFeedTest extends FeedMessageTest {
         feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
         
         errors = tripIdValidator.validate(gtfsData, feedMessageBuilder.build());
-        assertEquals(0, errors.getOccurrenceList().size());
+        for (ErrorListHelperModel error : errors) {
+            assertEquals(0, error.getOccurrenceList().size());
+        }
         
         // setting invalid trip id = 100 that does not match with any trip id in static Gtfs data
         tripDescriptorBuilder.setTripId("100");
@@ -58,7 +61,9 @@ public class TripUpdateFeedTest extends FeedMessageTest {
         feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
         
         errors = tripIdValidator.validate(gtfsData, feedMessageBuilder.build());
-        assertEquals(1, errors.getOccurrenceList().size());
+        for (ErrorListHelperModel error : errors) {
+            assertEquals(1, error.getOccurrenceList().size());
+        }
         
         clearAndInitRequiredFeedFields();
     }
@@ -99,7 +104,9 @@ public class TripUpdateFeedTest extends FeedMessageTest {
         assertEquals(3, feedMessageBuilder.getEntity(0).getTripUpdate().getStopTimeUpdateCount());
         
         errors = stopSequenceValidator.validate(gtfsData, feedMessageBuilder.build());
-        assertEquals(1, errors.getOccurrenceList().size());
+        for (ErrorListHelperModel error : errors) {
+            assertEquals(1, error.getOccurrenceList().size());
+        }
         
         clearAndInitRequiredFeedFields();
     }
@@ -132,7 +139,9 @@ public class TripUpdateFeedTest extends FeedMessageTest {
         feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
         
         errors = vehicleIdValidator.validate(gtfsData, feedMessageBuilder.build());
-        assertEquals(1, errors.getOccurrenceList().size());
+        for (ErrorListHelperModel error : errors) {
+            assertEquals(1, error.getOccurrenceList().size());
+        }
         
         clearAndInitRequiredFeedFields();
     }
@@ -145,11 +154,15 @@ public class TripUpdateFeedTest extends FeedMessageTest {
         
         // gtfsData does not contain location_type = 1 for stop_id. Therefore returns 0 errors
         errors = stopLocationValidator.validate(gtfsData);
-        assertEquals(0, errors.getOccurrenceList().size());
+        for (ErrorListHelperModel error : errors) {
+            assertEquals(0, error.getOccurrenceList().size());
+        }
         
         // gtfsData2 contains location_type = 1 for stop_ids. Therefore returns errorcount = (number of location_type = 1 for stop_ids)
         errors = stopLocationValidator.validate(gtfsData2);
-        assertTrue(errors.getOccurrenceList().size() >= 1);
+        for (ErrorListHelperModel error : errors) {
+            assertTrue(error.getOccurrenceList().size() >= 1);
+        }
         
         clearAndInitRequiredFeedFields();
     }

--- a/src/test/java/edu/usf/cutr/gtfsrtvalidator/test/feeds/combined/TripUpdateVehiclePositionTest.java
+++ b/src/test/java/edu/usf/cutr/gtfsrtvalidator/test/feeds/combined/TripUpdateVehiclePositionTest.java
@@ -18,8 +18,8 @@ package edu.usf.cutr.gtfsrtvalidator.test.feeds.combined;
 
 import com.google.transit.realtime.GtfsRealtime;
 import edu.usf.cutr.gtfsrtvalidator.FeedMessageTest;
+import edu.usf.cutr.gtfsrtvalidator.helper.ErrorListHelperModel;
 import edu.usf.cutr.gtfsrtvalidator.validation.entity.combined.VehicleTripDescriptorValidator;
-import static junit.framework.TestCase.assertEquals;
 import org.junit.Test;
 
 /* 
@@ -57,7 +57,9 @@ public class TripUpdateVehiclePositionTest extends FeedMessageTest {
         
         // TripUpdate and VehiclePosition feed have same trip id = 1.1 and same vehicle id = 1. So, no errors.
         errors = vehicleAndTripDescriptorValidator.validate(gtfsData, feedMessageBuilder.build());
-        assertEquals(0, errors.getOccurrenceList().size());
+        for (ErrorListHelperModel error : errors) {
+            assertEquals(0, error.getOccurrenceList().size());
+        }
         
         /* If trip_id's and vehicle_id's in TripUpdate and VehiclePosition are not equal, validator should return an error.
            That is, it fails the validation and passes the assertion.
@@ -75,7 +77,9 @@ public class TripUpdateVehiclePositionTest extends FeedMessageTest {
         feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
         // 2 errors. Unmatched trip id's and vechicle id's in TripUpdate and VehiclePosition feeds
         errors = vehicleAndTripDescriptorValidator.validate(gtfsData, feedMessageBuilder.build());
-        assertEquals(2, errors.getOccurrenceList().size());
+        for (ErrorListHelperModel error : errors) {
+            assertEquals(2, error.getOccurrenceList().size());
+        }
         
         clearAndInitRequiredFeedFields();
     }

--- a/src/test/java/edu/usf/cutr/gtfsrtvalidator/test/feeds/combined/TripUpdateVehiclePostionAlertTest.java
+++ b/src/test/java/edu/usf/cutr/gtfsrtvalidator/test/feeds/combined/TripUpdateVehiclePostionAlertTest.java
@@ -18,8 +18,8 @@ package edu.usf.cutr.gtfsrtvalidator.test.feeds.combined;
 
 import com.google.transit.realtime.GtfsRealtime;
 import edu.usf.cutr.gtfsrtvalidator.FeedMessageTest;
+import edu.usf.cutr.gtfsrtvalidator.helper.ErrorListHelperModel;
 import edu.usf.cutr.gtfsrtvalidator.validation.entity.LocationTypeReferenceValidator;
-import static junit.framework.TestCase.assertEquals;
 import org.junit.Test;
 
 /*
@@ -61,7 +61,9 @@ public class TripUpdateVehiclePostionAlertTest extends FeedMessageTest {
         
         // all the feeds have valid stop id matching that in static Gtfs data. So, returns 0 errors
         errors = locationValidator.validate(gtfsData, feedMessageBuilder.build());
-        assertEquals(0, errors.getOccurrenceList().size());
+        for (ErrorListHelperModel error : errors) {
+            assertEquals(0, error.getOccurrenceList().size());
+        }
         
         // setting stop id = "DUMMY" in TripUpdate feed that does not match with any stop id in static Gtfs data
         stopTimeUpdateBuilder.setStopId("DUMMY");
@@ -70,14 +72,18 @@ public class TripUpdateVehiclePostionAlertTest extends FeedMessageTest {
         feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
         errors = locationValidator.validate(gtfsData, feedMessageBuilder.build());
         // one error from TripUpdate feed stop_id = "DUMMY". VehiclePosition and Alert feeds have valid stop id = "A"
-        assertEquals(1, errors.getOccurrenceList().size());
+        for (ErrorListHelperModel error : errors) {
+            assertEquals(1, error.getOccurrenceList().size());
+        }
         
         vehiclePositionBuilder.setStopId("DUMMY");
         feedEntityBuilder.setVehicle(vehiclePositionBuilder.build());
         feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
         errors = locationValidator.validate(gtfsData, feedMessageBuilder.build());
         // 2 errors from TripUpdate and VehiclePosition feeds stop_id="DUMMY". Alert feed have valid stop id ="A"
-        assertEquals(2, errors.getOccurrenceList().size());
+        for (ErrorListHelperModel error : errors) {
+            assertEquals(2, error.getOccurrenceList().size());
+        }
         
         entitySelectorBuilder.setStopId("DUMMY");
         alertBuilder.addInformedEntity(entitySelectorBuilder.build());
@@ -85,7 +91,9 @@ public class TripUpdateVehiclePostionAlertTest extends FeedMessageTest {
         feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
         errors = locationValidator.validate(gtfsData, feedMessageBuilder.build());
         // 3 errors from TripUpdate, VehiclePosition and alert feeds stop_id="DUMMY"
-        assertEquals(3, errors.getOccurrenceList().size());
+        for (ErrorListHelperModel error : errors) {
+            assertEquals(3, error.getOccurrenceList().size());
+        }
         
         clearAndInitRequiredFeedFields();
     }    

--- a/src/test/java/edu/usf/cutr/gtfsrtvalidator/test/headerandentity/FeedHeaderTest.java
+++ b/src/test/java/edu/usf/cutr/gtfsrtvalidator/test/headerandentity/FeedHeaderTest.java
@@ -18,38 +18,50 @@ package edu.usf.cutr.gtfsrtvalidator.test.headerandentity;
 
 import com.google.transit.realtime.GtfsRealtime;
 import edu.usf.cutr.gtfsrtvalidator.FeedMessageTest;
+import edu.usf.cutr.gtfsrtvalidator.helper.ErrorListHelperModel;
 import edu.usf.cutr.gtfsrtvalidator.validation.entity.TimestampValidation;
-import java.util.Date;
 import org.junit.Test;
-import static junit.framework.TestCase.assertEquals;
+
+import java.util.Date;
+import java.util.List;
+
+import static edu.usf.cutr.gtfsrtvalidator.validation.ValidationRules.E012;
 
 /*
  * Tests all the warnings and rules that validate FeedHeader.
- * Tests: w001 - "Timestamps should be populated for all elements"
+ * Tests:
+ *  * w001 - "Timestamps should be populated for all elements"
+ *  * e012 - "Header timestamp should be greater than or equal to all other timestamps"
+ *
 */
 public class FeedHeaderTest extends FeedMessageTest {
-    
-    public final static long POSIX_TIME_PASS_VALIDATION = new Date().getTime()/1000; // current date in seconds
+
+    public final static long POSIX_TIME_PASS_VALIDATION = new Date().getTime() / 1000; // current date in seconds
     public final static long POSIX_TIME_FAIL_VALIDATION = new Date().getTime();
-    
-    public FeedHeaderTest() throws Exception {}
-    
+
+    public FeedHeaderTest() throws Exception {
+    }
+
     @Test
-    public void testTimestampValidation() {
+    public void testTimestampValidationW001() {
         TimestampValidation timestampValidation = new TimestampValidation();
         GtfsRealtime.TripDescriptor.Builder tripDescriptorBuilder = GtfsRealtime.TripDescriptor.newBuilder();
-        
+
         // Timestamp will be zero initially in FeedHeader, TripUpdate and VehiclePosition. Should return 3 error.
         errors = timestampValidation.validate(gtfsData, feedMessageBuilder.build());
-        assertEquals(3, errors.getOccurrenceList().size());
-        
+        for (ErrorListHelperModel error : errors) {
+            assertEquals(3, error.getOccurrenceList().size());
+        }
+
         // Populate timestamp to any value greater than zero in FeedHeader
         feedHeaderBuilder.setTimestamp(12345);
         feedMessageBuilder.setHeader(feedHeaderBuilder.build());
         // Invalid timestamp in TripUpdate and VehiclePosition. Should return 2 errors.
         errors = timestampValidation.validate(gtfsData, feedMessageBuilder.build());
-        assertEquals(2, errors.getOccurrenceList().size());
-        
+        for (ErrorListHelperModel error : errors) {
+            assertEquals(2, error.getOccurrenceList().size());
+        }
+
         // TripDescriptor is a required field in tripUpdate
         tripUpdateBuilder.setTrip(tripDescriptorBuilder.build());
         feedEntityBuilder.setTripUpdate(tripUpdateBuilder.build());
@@ -60,15 +72,128 @@ public class FeedHeaderTest extends FeedMessageTest {
         feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
         // Invalid timestamp only in VehiclePosition. Should return 1 errors.
         errors = timestampValidation.validate(gtfsData, feedMessageBuilder.build());
-        assertEquals(1, errors.getOccurrenceList().size());
-        
+        for (ErrorListHelperModel error : errors) {
+            assertEquals(1, error.getOccurrenceList().size());
+        }
+
         vehiclePositionBuilder.setTimestamp(12345);
         feedEntityBuilder.setVehicle(vehiclePositionBuilder.build());
         feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
         // Now timestamp is populated in FeedHeader, TripUpdate and VehiclePosition . Should return no error.
         errors = timestampValidation.validate(gtfsData, feedMessageBuilder.build());
-        assertEquals(0, errors.getOccurrenceList().size());
-        
+        for (ErrorListHelperModel error : errors) {
+            assertEquals(0, error.getOccurrenceList().size());
+        }
+
         clearAndInitRequiredFeedFields();
+    }
+
+    @Test
+    public void testTimestampValidationE012() {
+        TimestampValidation timestampValidation = new TimestampValidation();
+        GtfsRealtime.TripDescriptor.Builder tripDescriptorBuilder = GtfsRealtime.TripDescriptor.newBuilder();
+
+        /**
+         * Header timestamp greater than other entities - no error
+         */
+        feedHeaderBuilder.setTimestamp(5);
+        feedMessageBuilder.setHeader(feedHeaderBuilder.build());
+
+        tripUpdateBuilder.setTimestamp(4);
+        tripUpdateBuilder.setTrip(tripDescriptorBuilder.build());
+        feedEntityBuilder.setTripUpdate(tripUpdateBuilder);
+
+        vehiclePositionBuilder.setTimestamp(4);
+        feedEntityBuilder.setVehicle(vehiclePositionBuilder.build());
+
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        errors = timestampValidation.validate(gtfsData, feedMessageBuilder.build());
+        for (ErrorListHelperModel error : errors) {
+            assertEquals(0, error.getOccurrenceList().size());
+        }
+
+        /**
+         * Header timestamp equal to other entities - no error
+         */
+        tripUpdateBuilder.setTimestamp(5);
+        tripUpdateBuilder.setTrip(tripDescriptorBuilder.build());
+        feedEntityBuilder.setTripUpdate(tripUpdateBuilder);
+
+        vehiclePositionBuilder.setTimestamp(5);
+        feedEntityBuilder.setVehicle(vehiclePositionBuilder.build());
+
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        errors = timestampValidation.validate(gtfsData, feedMessageBuilder.build());
+        for (ErrorListHelperModel error : errors) {
+            assertEquals(0, error.getOccurrenceList().size());
+        }
+
+        /**
+         * Header timestamp less than VehiclePosition timestamp - 1 error
+         */
+        tripUpdateBuilder.setTimestamp(5);
+        tripUpdateBuilder.setTrip(tripDescriptorBuilder.build());
+        feedEntityBuilder.setTripUpdate(tripUpdateBuilder);
+
+        vehiclePositionBuilder.setTimestamp(6);
+        feedEntityBuilder.setVehicle(vehiclePositionBuilder.build());
+
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        // Feed header timestamp is less than VehiclePosition - we should see one error of type E012
+        errors = timestampValidation.validate(gtfsData, feedMessageBuilder.build());
+        _assertE012Errors(errors, 1);
+
+        /**
+         * Header timestamp less than TripUpdate timestamp - 1 error
+         */
+        tripUpdateBuilder.setTimestamp(6);
+        tripUpdateBuilder.setTrip(tripDescriptorBuilder.build());
+        feedEntityBuilder.setTripUpdate(tripUpdateBuilder);
+
+        vehiclePositionBuilder.setTimestamp(5);
+        feedEntityBuilder.setVehicle(vehiclePositionBuilder.build());
+
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        // Feed header timestamp is less than TripUpdate - we should see one error of type E012
+        errors = timestampValidation.validate(gtfsData, feedMessageBuilder.build());
+        _assertE012Errors(errors, 1);
+
+        /**
+         * Header timestamp less than TripUpdate and VehiclePosition timestamps - 2 errors
+         */
+        tripUpdateBuilder.setTimestamp(6);
+        tripUpdateBuilder.setTrip(tripDescriptorBuilder.build());
+        feedEntityBuilder.setTripUpdate(tripUpdateBuilder);
+
+        vehiclePositionBuilder.setTimestamp(6);
+        feedEntityBuilder.setVehicle(vehiclePositionBuilder.build());
+
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        // Feed header timestamp is less than VehiclePosition and TripUpdate - we should see two errors of type E012
+        errors = timestampValidation.validate(gtfsData, feedMessageBuilder.build());
+        _assertE012Errors(errors, 2);
+
+        clearAndInitRequiredFeedFields();
+    }
+
+    /**
+     * Asserts that errors is found due to an entity having a timestamp greater than the header
+     *
+     * @param errors              list of errors output from validation
+     * @param totalExpectedErrors total number of expected errors
+     */
+    private void _assertE012Errors(List<ErrorListHelperModel> errors, int totalExpectedErrors) {
+        for (ErrorListHelperModel error : errors) {
+            if (error.getErrorMessage().getValidationRule().getErrorId().equals(E012.getErrorId())) {
+                assertEquals(totalExpectedErrors, error.getOccurrenceList().size());
+            } else {
+                assertEquals(0, error.getOccurrenceList().size());
+            }
+        }
     }
 }


### PR DESCRIPTION
**Summary:**

* Implements new error rule for #102 - "E012 - Header timestamp should be greater than or equal to all other timestamps"
* For processing efficiency, allow for checking for more than one error/warning within the same implementation of `FeedEntityValidator` - this means passing back more than one `ErrorListHelperModel` from the `validate()` method.  This avoids us looping through the entire dataset more than once for errors/warnings that are related and that we can catch in the same pass.  For example, in `TimestampValidation` we now check if the timestamp is populated, and if the timestamps are greater than the feed header timestamp within the same loop.

@mohangandhiGH Could you please review this?  Please double-check to make sure I'm not missing any other assumption the tool is making regarding the old format of passing back a single type of error/warning from `.validate()`.