### PR TITLE
Fix#98 - Show users detailed error messages in the UI

### DIFF
--- a/src/main/resources/webroot/custom-js/loading.js
+++ b/src/main/resources/webroot/custom-js/loading.js
@@ -17,6 +17,7 @@
 
 var validGtfs = false;
 var validGtfsRT = false;
+var errorMessage = [];
 var validUrlList = {};
 validUrlList.gtfsFeeds = [];
 
@@ -105,15 +106,16 @@ function monitorGtfsRtFeeds(gtfsrtUrlList, gtfsFeedId) {
             }
 
             function feedError(data) {
-                alert(JSON.stringify(data));
-
-                var responseJson = data["responseJSON"];
-                var message = responseJson["message"];
 
                 $(progressID).removeClass("progress-striped active");
                 $(progressID + " .progress-bar").addClass("progress-bar-warning");
 
-                $(progressID).prev().find(".status").text("("+ message +")");
+                $(progressID).prev().find(".status").text("(" + data.statusText + ")");
+
+                errorMessage["modalTitle"] = "GTFS-RT Feed error";
+                errorMessage["errorDescription"] = data.statusText + ". " + data["responseJSON"]["message"] +
+                                            ". Please check the URL \"" + url + "\" provided.";
+                displayModalDialog(errorMessage);
             }
 
             var jsonData = {"gtfsUrl":url, "gtfsFeedModel":{"feedId": gtfsFeedId}};
@@ -145,19 +147,20 @@ function downloadGTFSFeed() {
     function feedErrorDisplay(message) {
         $(progressID).removeClass("progress-striped active");
         $(progressID + " .progress-bar").addClass("progress-bar-danger");
-        $(progressID).prev().find(".status").text("("+ message +")");
+        $(progressID).prev().find(".status").text("(" + message["title"] + ")");
         validGtfs = false;
+
+        message["modalTitle"] = "GTFS Feed error";
+        displayModalDialog(message);
     }
 
-    if (paramVal === null) {
+    if (paramVal === null || paramVal === "") {
         //No URL for the given feed entered. Show status
-        feedErrorDisplay("No GTFS URL Given");
-
-    } else if (paramVal === "") {
-        //No URL for the given feed entered. Show status
-        feedErrorDisplay("No GTFS URL Given");
+        errorMessage["title"] = "Invalid URL";
+        errorMessage["errorDescription"] = "No GTFS URL Given";
+        feedErrorDisplay(errorMessage);
     } else {
-        function feedSuccess(data){
+        function feedSuccess(data) {
             if (data["feedId"] != null) {
                 $(progressID).removeClass("progress-striped active");
                 $(progressID + " .progress-bar").addClass("progress-bar-success");
@@ -167,13 +170,15 @@ function downloadGTFSFeed() {
                 //gtfsRtfeeds can only be started with a valid id
                 monitorGtfsRtFeeds(gtfsrtUrlList, data["feedId"]);
                 checkStatus();
-            }else{
-                feedErrorDisplay(data["title"]);
+            } else {
+                feedErrorDisplay(data);
             }
         }
 
-        function feedError(xhr,status,error){
-            feedErrorDisplay(status);
+        function feedError(xhr,status,error) {
+            errorMessage["title"] = xhr["responseJSON"]["title"];
+            errorMessage["errorDescription"] = error + ". " + xhr["responseJSON"]["message"];
+            feedErrorDisplay(errorMessage);
         }
 
         $.ajax({
@@ -189,6 +194,14 @@ function downloadGTFSFeed() {
             dataType: 'json'
         });
     }
+}
+
+function displayModalDialog(message) {
+    var errorTemplateScript = $("#gtfs-error-modal").html();
+    var errorTemplate = Handlebars.compile(errorTemplateScript);
+    var compiledHtml = errorTemplate(message);
+    $('.gtfs-error-message').html(compiledHtml);
+    $("#myModal").modal();
 }
 
 //Generates the progress bars for the list of RealTime Feeds provided

--- a/src/main/resources/webroot/loading.html
+++ b/src/main/resources/webroot/loading.html
@@ -77,6 +77,10 @@
                 </div>
             </div>
     </div>
+
+    <div class="gtfs-error-message">
+    </div>
+
 </div>
 
 <!-- /.container -->
@@ -93,6 +97,30 @@
             <div class="progress-bar" style="width: 100%"></div>
         </div>
         {{/each}}
+</script>
+
+<script id="gtfs-error-modal" type="text/x-handlebars-template">
+    <div id="myModal" class="modal fade" role="dialog">
+        <div class="modal-dialog">
+
+            <!-- Modal content-->
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                    <h4 class="modal-title">{{modalTitle}}</h4>
+                </div>
+                <div class="modal-body">
+                    <p>{{errorDescription}}</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+                </div>
+            </div>
+
+        </div>
+    </div>
 </script>
 
 <script src="custom-js/loading.js" type="application/javascript"></script>

--- a/src/test/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsFeedTest.java
+++ b/src/test/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsFeedTest.java
@@ -51,7 +51,7 @@ public class GtfsFeedTest extends TestCase {
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
 
         response = gtfsFeed.postGtfsFeed(downloadFailURL);
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertTrue(Response.Status.BAD_REQUEST.getStatusCode() == response.getStatus() || Response.Status.FORBIDDEN.getStatusCode() == response.getStatus());
 
         response = gtfsFeed.postGtfsFeed(badGTFS);
         assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());


### PR DESCRIPTION
**Summary:**

Here are some screenshots of error messages for invalid requests. 
*  Provide an invalid static gtfs URL [http://gohart.org/google/google_transit2.zip](http://gohart.org/google/google_transit2.zip) and valid GTFS-RT feed [ http://api.tampa.onebusaway.org:8088/trip-updates]( http://api.tampa.onebusaway.org:8088/trip-updates). It displays the error as

![image](https://cloud.githubusercontent.com/assets/17164961/24644840/91d2165a-18e3-11e7-8c1a-8eced2a7c309.png)

*  Provide a valid static gtfs URL [http://gohart.org/google/google_transit.zip](http://gohart.org/google/google_transit.zip) and valid GTFS-RT feed [ http://api.tampa.onebusaway.org:8088/trip-upda]( http://api.tampa.onebusaway.org:8088/trip-upda). It displays the error as

![image](https://cloud.githubusercontent.com/assets/17164961/24644889/d198fe98-18e3-11e7-8464-aed1b668fb9f.png)

Fixes #98. 


**Expected behavior:** 

The application is expected to show detailed error mesage in UI.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "Fix #issue - short description of fix and changes"
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
