### PR TITLE
Fix #122 - Change minimum limit of update interval to 1 second

### DIFF
--- a/src/main/resources/webroot/index.html
+++ b/src/main/resources/webroot/index.html
@@ -104,7 +104,10 @@
                                                 class="glyphicon glyphicon-minus-sign"></span> Remove Feed</a>
                                     </div>
                                     <div class="col-md-6">
-                                        <span class="pull-right">Interval(sec.): <input name="updateInterval" type="number" value="10" min="10" step="1"/></span>
+                                        <span class="pull-right">Interval (sec.):
+                                        <input name="updateInterval" type="number" value="10" min="1" step="1"
+                                               oninvalid="setCustomValidity('Interval must be at least 1 second')"
+                                               onchange="try{setCustomValidity('')}catch(e){}"/></span>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
**Summary:**

* Allow setting minimum update interval down to 1 second
* Tweak invalid value text
* However, it seems like this interval isn't actually being used to query the feed??  I'm opening another issue at for this at https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/130.

**Expected behavior:** 

I can now set the minimum interval down to 1 second, and I get the message "Interval must be at least one second" if I set it less than that.

@mohangandhiGH Could you please take a look?