### PR TITLE
Fix #130 - Use user-provided interval to refresh GTFS-rt feed

### DIFF
--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsRtFeed.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsRtFeed.java
@@ -127,8 +127,8 @@ public class GtfsRtFeed {
     private static HashMap<String, ScheduledExecutorService> runningTasks = new HashMap<>();
 
     @PUT
-    @Path("/{id}/monitor")
-    public Response getID(@PathParam("id") int id, @DefaultValue("10") @QueryParam("updateInterval") int updateInterval) {
+    @Path("/{id}/{updateInterval}/monitor")
+    public Response getID(@PathParam("id") int id, @PathParam("updateInterval") int updateInterval) {
         //Get RtFeedModel from id
         Session session = GTFSDB.InitSessionBeginTrans();
         GtfsRtFeedModel gtfsRtFeed = (GtfsRtFeedModel) session.createQuery(" FROM GtfsRtFeedModel "

--- a/src/main/resources/webroot/custom-js/monitoring.js
+++ b/src/main/resources/webroot/custom-js/monitoring.js
@@ -28,8 +28,8 @@ var setIntervalGetFeeds;
 var setIntervalClock;
 
 //Retrieve the update interval value
-var updateInterval = localStorage.getItem("updateInterval");
-updateInterval = updateInterval * 1000;
+var serverUpdateInterval = localStorage.getItem("updateInterval");
+var updateInterval = (serverUpdateInterval / 2) * 1000;
 
 var hideErrors = [];
 var paginationLog = [];
@@ -42,7 +42,7 @@ var toggleDataOff = '<input type="checkbox" data-toggle="toggle" data-onstyle="s
 for (var gtfsRtFeed in gtfsRtFeeds) {
     if (gtfsRtFeeds.hasOwnProperty(gtfsRtFeed)) {
         $.ajax({
-            url: "http://localhost:8080/api/gtfs-rt-feed/" + gtfsRtFeeds[gtfsRtFeed]["feedId"] + "/monitor",
+            url: "http://localhost:8080/api/gtfs-rt-feed/" + gtfsRtFeeds[gtfsRtFeed]["feedId"] + "/" + serverUpdateInterval + "/monitor",
             type: 'PUT',
             success: function (data) {
                 initializeInterface(data);


### PR DESCRIPTION
**Summary:**

Fixes #130. 

**Expected behavior:** 

The update interval of server is set to user entered interval in welcome page.
Update interval of client is set to half the update interval of server refresh rate.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "Fix #issue - short description of fix and changes"
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
