### PR TITLE
Fix #140 - Use OccurrenceModel ValidationRule to generate occurrence summary

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -15,11 +15,12 @@
 |---------------|---------------------------|
 | [E001](#E001) | Not in POSIX time
 | [E002](#E002) | Unsorted `stop_sequence`
-| [E003](#E003) | `trip_id` mismatch in GTFS-rt and GTFS
-| [E004](#E004) | `route_id` mismatch in GTFS-rt and GTFS
+| [E003](#E003) | GTFS-rt `trip_id` does not appear in GTFS data
+| [E004](#E004) | GTFS-rt `route_id` does not appear in GTFS data
 | [E010](#E010) | `location_type` not `0` in `stops.txt` (Note that this is implemented but not executed because it's specific to GTFS - see #126)
 | [E011](#E011) | `location_type` not `0` in GTFS-rt
 | [E012](#E012) | Header timestamp should be greater than or equal to all other timestamps
+| [E013](#E013) | Frequency type 0 trip schedule_relationship should be UNSCHEDULED or empty
 
 # Warnings
 
@@ -68,13 +69,13 @@ See:
 
 <a name="E003"/>
 
-### E003 - `trip_id` mismatch in GTFS-rt and GTFS
+### E003 - GTFS-rt `trip_id` does not appear in GTFS data
 
 All `trip_ids` provided in the GTFS-rt feed must appear in the GTFS data
 
 <a name="E004"/>
 
-### E004 - `route_id` mismatch in GTFS-rt and GTFS
+### E004 - GTFS-rt `route_id` does not appear in GTFS data
 
 All `route_ids` provided in the GTFS-rt feed must appear in the GTFS data
 
@@ -97,3 +98,9 @@ All `stop_ids` referenced in GTFS-rt feeds must have the `location_type` = `0`
 ### E012 - Header timestamp should be greater than or equal to all other timestamps
 
 No timestamps for individual entities (TripUpdate, VehiclePosition, Alerts) in the feeds should be greater than the header timestamp.
+
+<a name="E013"/>
+
+### E013 - Frequency type 0 trip schedule_relationship should be UNSCHEDULED or empty
+
+For frequency-based exact_times=0 trips, schedule_relationship should be UNSCHEDULED or empty.

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/OccurrenceModel.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/OccurrenceModel.java
@@ -17,8 +17,6 @@
 
 package edu.usf.cutr.gtfsrtvalidator.api.model;
 
-import org.hibernate.annotations.Type;
-
 import javax.persistence.*;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
@@ -27,9 +25,9 @@ import java.io.Serializable;
 @Entity
 @Table(name="Occurrence")
 public class OccurrenceModel implements Serializable {
-    public OccurrenceModel(String elementPath, String elementValue) {
-        this.elementPath = elementPath;
-        this.elementValue = elementValue;
+
+    public OccurrenceModel(String prefix) {
+        this.prefix = prefix;
     }
 
     public OccurrenceModel() {
@@ -39,14 +37,27 @@ public class OccurrenceModel implements Serializable {
     @Column(name="occurrenceID")
     @GeneratedValue(strategy=GenerationType.IDENTITY)
     private int occurrenceId;
+
     @ManyToOne
     @JoinColumn(name = "messageID")
     private MessageLogModel messageLogModel;
-    @Column(name="elementPath")
-    private String elementPath;
-    @Column(name="elementValue")
-    @Type(type = "text")
-    private String elementValue;
+
+    /**
+     * This is used along with ValidationRule.occurrenceSuffix to create a description of this occurrence of an error/warning.
+     * <p>
+     * For example, for E004 "GTFS-rt trip_ids must appear in GTFS data", the error message we want to show the user could be
+     * "trip_id 6234 doesn't appear in the GTFS data"
+     * <p>
+     * For this message, the prefix would be:
+     * "trip_id 6234"
+     * <p>
+     * And the second part of the text (stored in ValidationRule.occurrenceSuffix) would be:
+     * "doesn't appear in the GTFS data"
+     *
+     * @see ValidationRule
+     */
+    @Column(name = "prefix")
+    private String prefix;
 
     public int getOccurrenceId() {
         return occurrenceId;
@@ -64,19 +75,11 @@ public class OccurrenceModel implements Serializable {
         this.messageLogModel = messageLogModel;
     }
 
-    public String getElementPath() {
-        return elementPath;
+    public String getPrefix() {
+        return prefix;
     }
 
-    public void setElementPath(String elementPath) {
-        this.elementPath = elementPath;
-    }
-
-    public String getElementValue() {
-        return elementValue;
-    }
-
-    public void setElementValue(String elementValue) {
-        this.elementValue = elementValue;
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
     }
 }

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/ValidationRule.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/ValidationRule.java
@@ -34,22 +34,45 @@ public class ValidationRule implements Serializable {
     @Id
     @Column(name="errorID")
     private String errorId;
+
     @Column(name = "severity")
     private String severity;
+
     @Column(name = "title")
     @Type(type = "text")
     private String title;
+
     @Column(name="errorDescription")
     @Type(type = "text")
     private String errorDescription;
 
-    public ValidationRule() {}
+    /**
+     * Text used to help describe an occurrence of this warning/error following the specific elements that it relates to.
+     * <p>
+     * For example, for E004 "GTFS-rt trip_ids must appear in GTFS data", the error message we want to show the user could be
+     * * "trip_id 6234 doesn't appear in the GTFS data"
+     * <p>
+     * For this message, the occurenceSuffix would be:
+     * * "doesn't appear in the GTFS data"
+     * <p>
+     * And the first part of the text (stored in OccurrenceModel.prefix) would be:
+     * * "trip_id 6234"
+     *
+     * @see OccurrenceModel
+     */
+    @Column(name = "occurrenceSuffix")
+    @Type(type = "text")
+    private String occurrenceSuffix;
 
-    public ValidationRule(String errorId, String severity, String title, String errorDescription) {
+    public ValidationRule() {
+    }
+
+    public ValidationRule(String errorId, String severity, String title, String errorDescription, String occurrenceSuffix) {
         this.setErrorId(errorId);
         this.setSeverity(severity);
         this.setTitle(title);
         this.setErrorDescription(errorDescription);
+        this.setOccurrenceSuffix(occurrenceSuffix);
     }
 
     public String getErrorDescription() {
@@ -82,5 +105,13 @@ public class ValidationRule implements Serializable {
 
     public void setTitle(String title) {
         this.title = title;
+    }
+
+    public String getOccurrenceSuffix() {
+        return occurrenceSuffix;
+    }
+
+    public void setOccurrenceSuffix(String occurenceSuffix) {
+        this.occurrenceSuffix = occurenceSuffix;
     }
 }

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/ValidationRules.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/ValidationRules.java
@@ -23,43 +23,55 @@ public class ValidationRules {
      * Warnings
      */
     public static final ValidationRule W001 = new ValidationRule("W001", "WARNING", "Timestamp not populated",
-            "Timestamps should be populated for all elements");
+            "Timestamps should be populated for all elements",
+            "does not have a timestamp");
     public static final ValidationRule W002 = new ValidationRule("W002", "WARNING", "Vehicle_id not populated",
-            "vehicle_id should be populated in trip_update");
+            "vehicle_id should be populated in trip_update",
+            "does not have a vehicle_id");
     public static final ValidationRule W003 = new ValidationRule("W003", "WARNING", "VehiclePosition and TripUpdate feed mismatch",
-            "If both vehicle positions and trip updates are provided, VehicleDescriptor or TripDescriptor values should match between the two feeds");
+            "If both vehicle positions and trip updates are provided, VehicleDescriptor or TripDescriptor values should match between the two feeds",
+            "does not appear in both VehiclePositions and TripUpdates feeds");
 
     /**
      * Errors
      */
     public static final ValidationRule E001 = new ValidationRule("E001", "ERROR", "Not in POSIX time",
-            "All timestamps must be in POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC)");
+            "All timestamps must be in POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC)",
+            "is not POSIX time");
     public static final ValidationRule E002 = new ValidationRule("E002", "ERROR", "Unsorted stop_sequence",
-            "stop_time_updates for a given trip_id must be sorted by increasing stop_sequence");
-    public static final ValidationRule E003 = new ValidationRule("E003", "ERROR", "Trip_id mismatch in GTFS-rt and GTFS",
-            "All trip_ids provided in the GTFS-rt feed must appear in the GTFS data");
-    public static final ValidationRule E004 = new ValidationRule("E004", "ERROR", "Route_id mismatch in GTFS-rt and GTFS",
-            "All route_ids provided in the GTFS-rt feed must appear in the GTFS data");
+            "stop_time_updates for a given trip_id must be sorted by increasing stop_sequence",
+            "is not sorted by increasing stop_sequence");
+    public static final ValidationRule E003 = new ValidationRule("E003", "ERROR", "GTFS-rt trip_id does not appear in GTFS data",
+            "All trip_ids provided in the GTFS-rt feed must appear in the GTFS data",
+            "does not appear in the GTFS data");
+    public static final ValidationRule E004 = new ValidationRule("E004", "ERROR", "GTFS-rt route_id does not appear in GTFS data",
+            "All route_ids provided in the GTFS-rt feed must appear in the GTFS data",
+            "does not appear in the GTFS data");
 
     // TODO - implement
     public static final ValidationRule E005 = new ValidationRule("E005", "ERROR", "GTFS stop_times.txt does not contain arrival_times and/or departure_times for all stops referenced in the GTFS-rt feed",
-            "If only delay is provided in a stop_time_event (and not a time), then the GTFS stop_times.txt must contain arrival_times and/or departure_times for all stops referenced in the GTFS-rt feed (i.e., not just timepoints)");
+            "If only delay is provided in a stop_time_event (and not a time), then the GTFS stop_times.txt must contain arrival_times and/or departure_times for all stops referenced in the GTFS-rt feed (i.e., not just timepoints)",
+            "has only delay but no arrival and/or departure time");
 
     // TODO - implement - see https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/59
     public static final ValidationRule E006 = new ValidationRule("E006", "ERROR", "Missing trip_id and start_time in Frequency-based trip_updates",
-            "Frequency-based trip_updates must contain trip_id, start_time, and start_date");
+            "Frequency-based trip_updates must contain trip_id, start_time, and start_date",
+            "is missing trip_id and/or start_time");
 
     // TODO - implement
-    public static final ValidationRule E007 = new ValidationRule("E007", "ERROR", "All trips does not belong to the same block",
-            "If more than one trip_update has the same vehicle_id, then all trips must belong to the same block, and the arrival predictions for each trip must match the sequential order for the trips in the block. For example, if we have trip_ids 1, 2, and 3 that all belong to the same block, and the vehicle trips trip 1, then trip 2, and then trip 3, the arrival predictions should increase chronologically for trips 1, 2, and 3. For example, trip 3 predictions shouldn't be earlier than trip 2 predictions.");
+    public static final ValidationRule E007 = new ValidationRule("E007", "ERROR", "Trips with same vehicle_id do not belong to the same block",
+            "If more than one trip_update has the same vehicle_id, then all trips must belong to the same block",
+            "do not belong to the same block but have the same vehicle_id");
 
     // TODO - implement
-    public static final ValidationRule E008 = new ValidationRule("E008", "ERROR", "In the GTFS-rt data, the tripId for each TripUpdate.TripDescriptor is not provided",
-            "If a GTFS block (defined by block_id in trips.txt) contains multiple references to the same stopId (i.e., the bus visits the same stopId more than once in the same block), but in different trips, then in the GTFS-rt data the tripId for each TripUpdate.TripDescriptor must be provided. In this case, the bus wouldn't visit the same stopId more than once in the same trip.");
+    public static final ValidationRule E008 = new ValidationRule("E008", "ERROR", "trip_id for each TripUpdate.TripDescriptor is not provided",
+            "If a GTFS block contains multiple references to the same stopId (i.e., the bus visits the same stopId more than once in the same block), but in different trips, then in the GTFS-rt data the tripId for each TripUpdate.TripDescriptor must be provided. In this case, the bus wouldn't visit the same stopId more than once in the same trip.",
+            "does not have a trip_id");
 
     // TODO - implement - see https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/17
-    public static final ValidationRule E009 = new ValidationRule("E009", "ERROR", "In the GTFS-rt data, the stop_sequence for each TripUpdate.StopTimeUpdate is not provided",
-            "If a GTFS trip contains multiple references to the same stopId (i.e., the bus visits the same stopId more than once in the SAME trip), then in the GTFS-rt data the stop_sequence for each TripUpdate.StopTimeUpdate must be provided.");
+    public static final ValidationRule E009 = new ValidationRule("E009", "ERROR", "The stop_sequence for each TripUpdate.StopTimeUpdate is not provided",
+            "If a GTFS trip contains multiple references to the same stopId (i.e., the bus visits the same stopId more than once in the SAME trip), then in the GTFS-rt data the stop_sequence for each TripUpdate.StopTimeUpdate must be provided.",
+            "does not contain stop_sequence");
 
     /**
      * Issue: https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/8
@@ -68,7 +80,8 @@ public class ValidationRules {
      * Reference(s): https://developers.google.com/transit/gtfs/reference?hl=en#stop_timestxt
      */
     public static final ValidationRule E010 = new ValidationRule("E010", "ERROR", "location_type not 0 in stops.txt",
-            "If location_type is used in stops.txt, all stops referenced in stop_times.txt must have location_type of 0");
+            "If location_type is used in stops.txt, all stops referenced in stop_times.txt must have location_type of 0",
+            "is not location_type 0");
 
     /**
      * Type: Error (Implicitly stated in the GTFS specifications)
@@ -77,13 +90,20 @@ public class ValidationRules {
      * Reference(s): https://developers.google.com/transit/gtfs/reference?hl=en#stop_timestxt
      */
     public static final ValidationRule E011 = new ValidationRule("E011", "ERROR", "Location_type not 0 in GTFS-rt",
-            "All stop_ids referenced in GTFS-rt feeds must have the location_type = 0");
+            "All stop_ids referenced in GTFS-rt feeds must have the location_type = 0", "is not location_type 0");
     //---------------------------------------------------------------------------------------
     //endregion
 
     public static final ValidationRule E012 = new ValidationRule("E012", "ERROR", "Header timestamp should be greater than or equal to all other timestamps",
-            "No timestamps for individual entities (TripUpdate, VehiclePosition) in the feeds should be greater than the header timestamp");
+            "No timestamps for individual entities (TripUpdate, VehiclePosition) in the feeds should be greater than the header timestamp",
+            "is greater than the header");
 
     public static final ValidationRule E013 = new ValidationRule("E013", "ERROR", "Frequency type 0 trip schedule_relationship should be UNSCHEDULED or empty",
-            "For frequency-based exact_times=0 trips, schedule_relationship should be UNSCHEDULED or empty.");
+            "For frequency-based exact_times=0 trips, schedule_relationship should be UNSCHEDULED or empty.",
+            "schedule_relationship is not UNSCHEDULED or empty");
+
+    // TODO - implement
+    public static final ValidationRule E014 = new ValidationRule("E014", "ERROR", "Predictions for trips are out-of-order in the block",
+            "Arrival predictions for each trip in the feed must match the sequential order for the trips in the block. For example, if we have trip_ids 1, 2, and 3 that all belong to the same block, and the vehicle trips trip 1, then trip 2, and then trip 3, the arrival predictions should increase chronologically for trips 1, 2, and 3. For example, trip 3 predictions shouldn't be earlier in the feed than trip 2 predictions.",
+            "predictions are not ordered by appearance in block");
 }

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/entity/VehicleIdValidator.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/entity/VehicleIdValidator.java
@@ -21,7 +21,6 @@ import com.google.transit.realtime.GtfsRealtime;
 import edu.usf.cutr.gtfsrtvalidator.api.model.MessageLogModel;
 import edu.usf.cutr.gtfsrtvalidator.api.model.OccurrenceModel;
 import edu.usf.cutr.gtfsrtvalidator.helper.ErrorListHelperModel;
-import edu.usf.cutr.gtfsrtvalidator.validation.ValidationRules;
 import edu.usf.cutr.gtfsrtvalidator.validation.interfaces.FeedEntityValidator;
 import org.hsqldb.lib.StringUtil;
 import org.onebusaway.gtfs.impl.GtfsDaoImpl;
@@ -30,10 +29,12 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 
+import static edu.usf.cutr.gtfsrtvalidator.validation.ValidationRules.W002;
+
 
 /**
- * ID: w002
- * Description:vehicle_id should be populated in trip_update
+ * ID: W002
+ * Description: vehicle_id should be populated in trip_update
  */
 
 public class VehicleIdValidator implements FeedEntityValidator {
@@ -44,25 +45,22 @@ public class VehicleIdValidator implements FeedEntityValidator {
     public List<ErrorListHelperModel> validate(GtfsDaoImpl gtfsData, GtfsRealtime.FeedMessage feedMessage) {
         List<GtfsRealtime.FeedEntity> entityList = feedMessage.getEntityList();
         List<OccurrenceModel> errorOccurrenceList = new ArrayList<>();
-        int entityId = 0;
 
         for (GtfsRealtime.FeedEntity entity : entityList) {
             if (entity.hasTripUpdate()) {
-
                 GtfsRealtime.TripUpdate tripUpdate = entity.getTripUpdate();
                 //w002: vehicle_id should be populated in trip_update
                 if (StringUtil.isEmpty(tripUpdate.getVehicle().getId())) {
-                    OccurrenceModel errorOccurrence = new OccurrenceModel("$.entity["+ entityId +"].trip_update", null);
-                    errorOccurrenceList.add(errorOccurrence);
-                    _log.debug(ValidationRules.W002.getErrorDescription());
+                    OccurrenceModel om = new OccurrenceModel("trip_id " + tripUpdate.getTrip().getTripId());
+                    errorOccurrenceList.add(om);
+                    _log.debug(om.getPrefix() + " " + W002.getOccurrenceSuffix());
                 }
             }
-            entityId++;
         }
 
         List<ErrorListHelperModel> errors = new ArrayList<>();
         if (!errorOccurrenceList.isEmpty()) {
-            errors.add(new ErrorListHelperModel(new MessageLogModel(ValidationRules.W002), errorOccurrenceList));
+            errors.add(new ErrorListHelperModel(new MessageLogModel(W002), errorOccurrenceList));
         }
         return errors;
     }

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/entity/combined/FrequencyTypeZero.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/entity/combined/FrequencyTypeZero.java
@@ -20,13 +20,14 @@ import com.google.transit.realtime.GtfsRealtime;
 import edu.usf.cutr.gtfsrtvalidator.api.model.MessageLogModel;
 import edu.usf.cutr.gtfsrtvalidator.api.model.OccurrenceModel;
 import edu.usf.cutr.gtfsrtvalidator.helper.ErrorListHelperModel;
-import edu.usf.cutr.gtfsrtvalidator.validation.ValidationRules;
 import edu.usf.cutr.gtfsrtvalidator.validation.interfaces.FeedEntityValidator;
 import org.onebusaway.gtfs.impl.GtfsDaoImpl;
 import org.onebusaway.gtfs.model.Frequency;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+
+import static edu.usf.cutr.gtfsrtvalidator.validation.ValidationRules.E013;
 
 /**
  * ID: E013
@@ -57,21 +58,23 @@ public class FrequencyTypeZero implements FeedEntityValidator {
             GtfsRealtime.TripUpdate tripUpdate = entity.getTripUpdate();
             if (exactTimesZeroTrips.contains(tripUpdate.getTrip().getTripId()) &&
                     !(tripUpdate.getTrip().hasScheduleRelationship() || tripUpdate.getTrip().getScheduleRelationship().equals(GtfsRealtime.TripDescriptor.ScheduleRelationship.UNSCHEDULED))) {
-                _log.info("TripUpdate trip_id " + tripUpdate.getTrip().getTripId() + " is exact_times=0 and has an incorrect ScheduleRelationship of " + tripUpdate.getTrip().getScheduleRelationship());
-                errorListE013.add(new OccurrenceModel("trip_id " + tripUpdate.getTrip().getTripId(), "Incorrect ScheduleRelationship of " + tripUpdate.getTrip().getScheduleRelationship()));
+                OccurrenceModel om = new OccurrenceModel("trip_id " + tripUpdate.getTrip().getTripId() + " schedule_relationship " + tripUpdate.getTrip().getScheduleRelationship());
+                errorListE013.add(om);
+                _log.debug(om.getPrefix() + " " + E013.getOccurrenceSuffix());
             }
 
             GtfsRealtime.VehiclePosition vehiclePosition = entity.getVehicle();
             if (vehiclePosition.hasTrip() &&
                     exactTimesZeroTrips.contains(vehiclePosition.getTrip().getTripId()) &&
                     !(vehiclePosition.getTrip().hasScheduleRelationship() || vehiclePosition.getTrip().getScheduleRelationship().equals(GtfsRealtime.TripDescriptor.ScheduleRelationship.UNSCHEDULED))) {
-                _log.info("vehicle ID " + vehiclePosition.getVehicle().getId() + "trip_id " + vehiclePosition.getTrip().getTripId() + " is exact_times=0 and has an incorrect ScheduleRelationship of " + vehiclePosition.getTrip().getScheduleRelationship());
-                errorListE013.add(new OccurrenceModel("vehicle ID " + vehiclePosition.getVehicle().getId() + "trip_id " + vehiclePosition.getTrip().getTripId(), "Incorrect ScheduleRelationship of " + vehiclePosition.getTrip().getScheduleRelationship()));
+                OccurrenceModel om = new OccurrenceModel("vehicle_id " + vehiclePosition.getVehicle().getId() + " trip_id " + vehiclePosition.getTrip().getTripId() + " schedule_relationship " + vehiclePosition.getTrip().getScheduleRelationship());
+                errorListE013.add(om);
+                _log.debug(om.getPrefix() + " " + E013.getOccurrenceSuffix());
             }
         }
         List<ErrorListHelperModel> errors = new ArrayList<>();
         if (!errorListE013.isEmpty()) {
-            errors.add(new ErrorListHelperModel(new MessageLogModel(ValidationRules.E013), errorListE013));
+            errors.add(new ErrorListHelperModel(new MessageLogModel(E013), errorListE013));
         }
         return errors;
     }

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/gtfs/StopLocationTypeValidator.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/gtfs/StopLocationTypeValidator.java
@@ -50,7 +50,7 @@ public class StopLocationTypeValidator implements GtfsFeedValidator {
                 checkedStops.add(stopTime.getStop());
 
                 if (stopTime.getStop().getLocationType() != 0) {
-                    OccurrenceModel occurrenceModel = new OccurrenceModel("location_type is not 0 at ", stopTime.getStop().getName());
+                    OccurrenceModel occurrenceModel = new OccurrenceModel("stop_id " + stopTime.getStop().getId());
                     errorOccurrenceList.add(occurrenceModel);
                 }
             }

--- a/src/main/resources/simplelogger.properties
+++ b/src/main/resources/simplelogger.properties
@@ -5,4 +5,4 @@ handlers = org.eclipse.jetty.demo.SystemOutHandler
 org.slf4j.simpleLogger.log.org.eclipse.jetty = WARN
 org.slf4j.simpleLogger.log.org.hibernate = WARN
 org.slf4j.simpleLogger.log.org.onebusaway = WARN
-org.slf4j.simpleLogger.defaultLogLevel=INFO
+org.slf4j.simpleLogger.defaultLogLevel=DEBUG

--- a/src/test/java/edu/usf/cutr/gtfsrtvalidator/test/UtilTest.java
+++ b/src/test/java/edu/usf/cutr/gtfsrtvalidator/test/UtilTest.java
@@ -36,7 +36,7 @@ public class UtilTest {
     @Test
     public void testAssertResults() {
         MessageLogModel modelE001 = new MessageLogModel(ValidationRules.E001);
-        OccurrenceModel errorE001 = new OccurrenceModel("$.header.timestamp is not POSIX time", String.valueOf(MIN_POSIX_TIME));
+        OccurrenceModel errorE001 = new OccurrenceModel(String.valueOf(MIN_POSIX_TIME));
         List<OccurrenceModel> errorListE001 = new ArrayList<>();
 
 


### PR DESCRIPTION
**Summary:**

* By combining `OccurrenceModel.prefix + " " + ValidationRule.occurrenceSuffix`, a description of a particular occurrence of an error/warning can now be described.
* Prepares for showing occurence details in the UI via https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/139
* Simplify OccurrenceModel to fields that we're actually using
* Update all ValidationRules to include the suffix
* Change logging to use `OccurrenceModel.prefix + " " + ValidationRule.occurrenceSuffix`
* Add logging to rules that were missing logging
* Simplify StopTimeSequenceValidator - it was overly complex and building additional lists that aren't needed
* Refactoring for simplicity and code-cleanup
* Add missing rule description for E013 to Rules.md

**Expected behavior:** 

Same UI.  Change logging to OccurrenceModel and ValidationRule to enable the assembly of a summary description for a particular occurrence of an error/warning.

@mohangandhiGH You should be able to combine `OccurrenceModel.prefix + " " + ValidationRule.occurrenceSuffix` to get the "Summary" field value for a particular error/warning occurrence that's shown in the right-hand column.