### PR TITLE
Add tooltip for Log header 'Timestamp'

### DIFF
--- a/src/main/resources/webroot/custom-js/monitoring.js
+++ b/src/main/resources/webroot/custom-js/monitoring.js
@@ -345,3 +345,7 @@ function hideTooltip(btn) {
         btn.tooltip('hide');
     }, 1000);
 }
+
+$(document).ready(function(){
+    $("body").tooltip({ selector: '[data-toggle=tooltip]' });
+});

--- a/src/main/resources/webroot/monitoring.html
+++ b/src/main/resources/webroot/monitoring.html
@@ -167,7 +167,8 @@
                         <th>ID</th>
                         <th>Title</th>
                         <th>Severity</th>
-                        <th>Timestamp</th>
+                        <th data-toggle="tooltip" data-placement="top" title="GTFS-rt header timestamp">Timestamp <span class="glyphicon glyphicon-question-sign"></span>
+                        </th>
                     </tr>
                     </thead>
 


### PR DESCRIPTION
**Summary:**

PR  #135 already handles
*  All time-stamps (internal timestamp and GTFS-rt  timestamp) should be stored in milliseconds past epoch.
*  Iteration timestamp doesn't match GTFS-rt header timestamp

In this PR, we added a tooltip for Log table header `Timestamp`.

**Expected behavior:** 

When we hover on Log table header `Timestamp`, it will show tooltip "GTFS-rt header timestamp".


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "Fix #issue - short description of fix and changes"
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
