### PR TITLE
Fix #167 - Upload artifacts to Travis after CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,5 @@ cache:
 
 addons:
   artifacts: true
+    paths:
+    - $HOME/target/*.jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ cache:
 addons:
   artifacts:
     paths:
-    - $HOME/travis/.m2/repository/edu/usf/cutr/gtfs-rt-validator/*.jar
+    - $HOME/travis/.m2/repository/edu/usf/cutr/gtfs-rt-validator/1.0-SNAPSHOT/gtfs-rt-validator-1.0-SNAPSHOT.jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,7 @@ addons:
   artifacts:
     paths:
     - $HOME/travis/.m2/repository/edu/usf/cutr/gtfs-rt-validator/1.0-SNAPSHOT/gtfs-rt-validator-1.0-SNAPSHOT.jar
+
+deploy:
+  provider: s3
+  upload-dir: travis-builds

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,4 @@ cache:
 
 addons:
   artifacts: true
-    paths:
-    - $HOME/target/*.jar
+    paths: $HOME/target/*.jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ jdk: oraclejdk8
 cache:
   directories:
   - $HOME/.m2
+
+addons:
+  artifacts: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ cache:
 addons:
   artifacts:
     paths:
-    - $HOME/target/*.jar
+    - $HOME/travis/.m2/repository/edu/usf/cutr/gtfs-rt-validator/**/*.jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ cache:
   - $HOME/.m2
 
 addons:
-  artifacts: true
-    paths: $HOME/target/*.jar
+  artifacts:
+    paths:
+    - $HOME/target/*.jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ cache:
 addons:
   artifacts:
     paths:
-    - $HOME/travis/.m2/repository/edu/usf/cutr/gtfs-rt-validator/**/*.jar
+    - $HOME/travis/.m2/repository/edu/usf/cutr/gtfs-rt-validator/*.jar


### PR DESCRIPTION
**Summary:**

*Please don't merge*

This is a work-in-progress for uploading build artifacts from Travis to Amazon S3 bucket so we can always have the most recent JAR available for download.

See #167 for details.