### PR TITLE
Fix #139 - Add iteration details page to show problems found in that iteration

### DIFF
--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/ViewIterationErrorsModel.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/ViewIterationErrorsModel.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2017 University of South Florida.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.usf.cutr.gtfsrtvalidator.api.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.NamedNativeQuery;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+@Entity
+@NamedNativeQuery(name = "IterationIdErrors",
+        query = "SELECT ROWNUM() AS rowId, occurrenceId, " +
+                    "errorId, title, occurrencePrefix, occurrenceSuffix " +
+                "FROM Error " +
+                "INNER JOIN " +
+                    "(SELECT messageId, errorId, prefix AS occurrencePrefix, occurrenceId " +
+                    "FROM " +
+                    "Occurrence " +
+                    "INNER JOIN " +
+                        "(SELECT messageId, errorId " +
+                        "FROM MessageLog " +
+                        "WHERE iterationId = ?) MessageLogIteration " +
+                    "ON Occurrence.messageId = MessageLogIteration.messageId " +
+                    "WHERE messageId = ? ) OccurrenceList " +
+                "ON Error.errorId = OccurrenceList.errorId " +
+                "ORDER BY occurrenceId ",
+        resultClass = ViewIterationErrorsModel.class)
+public class ViewIterationErrorsModel {
+
+    @Id
+    @Column(name = "rowId")
+    private int rowId;
+
+    @Column(name = "occurrenceId")
+    private int occurrenceId;
+
+    @Column(name = "errorId")
+    private String errorId;
+
+    // Title of issue/warning from Error table matching errorId
+    @Column(name = "title")
+    private String title;
+
+    // prefix of issue/warning from Occurrence table
+    @Column(name = "occurrencePrefix")
+    private String occurrencePrefix;
+
+    @Column(name = "occurrenceSuffix")
+    private String occurrenceSuffix;
+
+    public int getRowId() {
+        return rowId;
+    }
+
+    public void setRowId(int rowId) {
+        this.rowId = rowId;
+    }
+
+    public int getOccurrenceId() {
+        return occurrenceId;
+    }
+
+    public void setOccurrenceId(int occurrenceId) {
+        this.occurrenceId = occurrenceId;
+    }
+
+    public String getErrorId() {
+        return errorId;
+    }
+
+    public void setErrorId(String errorId) {
+        this.errorId = errorId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getOccurrencePrefix() {
+        return occurrencePrefix;
+    }
+
+    public void setOccurrencePrefix(String occurrencePrefix) {
+        this.occurrencePrefix = occurrencePrefix;
+    }
+
+    public String getOccurrenceSuffix() {
+        return occurrenceSuffix;
+    }
+
+    public void setOccurrenceSuffix(String occurrenceSuffix) {
+        this.occurrenceSuffix = occurrenceSuffix;
+    }
+}

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsRtFeed.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsRtFeed.java
@@ -23,6 +23,7 @@ import edu.usf.cutr.gtfsrtvalidator.api.model.combined.CombinedIterationMessageM
 import edu.usf.cutr.gtfsrtvalidator.api.model.combined.CombinedMessageOccurrenceModel;
 import edu.usf.cutr.gtfsrtvalidator.background.BackgroundTask;
 import edu.usf.cutr.gtfsrtvalidator.db.GTFSDB;
+import edu.usf.cutr.gtfsrtvalidator.helper.IterationErrorListHelperModel;
 import edu.usf.cutr.gtfsrtvalidator.helper.MergeMonitorData;
 import org.hibernate.Session;
 import org.slf4j.LoggerFactory;
@@ -246,6 +247,67 @@ public class GtfsRtFeed {
         feedMessageModel.setJsonFeedMessage(feedMessageModel.getByteFeedMessage());
         return feedMessageModel.getJsonFeedMessage();
      }
+
+    // Returns feed errors/warnings for a requested iteration.
+    @GET
+    @Path("/{iterationId : \\d+}/iterationErrors")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getIterationErrors(
+            @PathParam("iterationId") int iterationId)  {
+
+        List<ViewIterationErrorsModel> viewIterationErrorsModelList;
+        IterationErrorListHelperModel iterationErrorListHelperModel;
+        List<IterationErrorListHelperModel> iterationErrorListHelperModelList = new ArrayList<>();
+
+        List<Integer> messageIdList;
+        Session session = GTFSDB.initSessionBeginTrans();
+
+        /*
+         * Get the list of messageIds for an iteration that helps in retrieving error/warning list from Occurrence table
+         * Each messageId corresponds to an errorId whose list of error occurrences are retrieved from Occurrence table
+         * ORDER BY errorId helps to have errors/warnings in ascending order i.e., first errors in ascending order then warnings in ascending order
+         */
+        messageIdList = session.createQuery(" SELECT messageId FROM MessageLogModel" +
+                                                " WHERE iterationId = " + iterationId +
+                                                " ORDER BY errorId")
+                                            .list();
+
+        GTFSDB.closeSession(session);
+
+        /*
+         * Each messageId corresponds to an error/warning that occurred in a particular iteration.
+         * Iterates over those rule/warning and retrieves list of occurrences of that error/warning and
+         *  adds it to the list of IterationErrorListHelperModel.
+         * We separately retrieve list of ViewIterationErrorsModel for each error/warning so that we can have
+         *  rowIds in increasing order starting from 1 and have separate list for each error/warning.
+         */
+        for (int messageId: messageIdList) {
+            session = GTFSDB.initSessionBeginTrans();
+            viewIterationErrorsModelList = session.createNamedQuery("IterationIdErrors", ViewIterationErrorsModel.class)
+                    .setParameter(0, iterationId)
+                    .setParameter(1, messageId)
+                    .list();
+            GTFSDB.closeSession(session);
+            if (!viewIterationErrorsModelList.isEmpty()) {
+                iterationErrorListHelperModel = new IterationErrorListHelperModel();
+
+                // viewIterationErrorsModelList contains the table data to display in each error/warning card.
+                iterationErrorListHelperModel.setViewIterationErrorsModelList(viewIterationErrorsModelList);
+
+                // Add errorId and title to IterationErrorListHelperModel that is used to display "ErrorId - Title" for each error/warning card in iteration.html
+                iterationErrorListHelperModel.setErrorId(viewIterationErrorsModelList.get(0).getErrorId());
+                iterationErrorListHelperModel.setTitle(viewIterationErrorsModelList.get(0).getTitle());
+                // Get the number of occurrences of each error/warning
+                iterationErrorListHelperModel.setErrorOccurrences(viewIterationErrorsModelList.size());
+
+                iterationErrorListHelperModelList.add(iterationErrorListHelperModel);
+            }
+        }
+
+        GenericEntity<List<IterationErrorListHelperModel>> iterationErrorList = new GenericEntity<List<IterationErrorListHelperModel>>(iterationErrorListHelperModelList) {
+        };
+        return Response.ok(iterationErrorList).build();
+    }
 
     @GET
     @Path("/{id}/{iteration}")

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/helper/IterationErrorListHelperModel.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/helper/IterationErrorListHelperModel.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2017 University of South Florida.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.usf.cutr.gtfsrtvalidator.helper;
+
+import edu.usf.cutr.gtfsrtvalidator.api.model.ViewIterationErrorsModel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class IterationErrorListHelperModel {
+
+    private List<ViewIterationErrorsModel> viewIterationErrorsModelList;
+    private String errorId;
+    private String title;
+    private int errorOccurrences;
+
+    public IterationErrorListHelperModel() {
+        this.viewIterationErrorsModelList = new ArrayList<>();
+    }
+
+    public List<ViewIterationErrorsModel> getViewIterationErrorsModelList() {
+        return viewIterationErrorsModelList;
+    }
+
+    public void setViewIterationErrorsModelList(List<ViewIterationErrorsModel> viewIterationErrorsModelList) {
+        this.viewIterationErrorsModelList = viewIterationErrorsModelList;
+    }
+
+    public String getErrorId() {
+        return errorId;
+    }
+
+    public void setErrorId(String errorId) {
+        this.errorId = errorId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public int getErrorOccurrences() {
+        return errorOccurrences;
+    }
+
+    public void setErrorOccurrences(int errorOccurrences) {
+        this.errorOccurrences = errorOccurrences;
+    }
+}

--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -27,5 +27,6 @@
     <mapping class="edu.usf.cutr.gtfsrtvalidator.api.model.ViewFeedMessageModel"/>
     <mapping class="edu.usf.cutr.gtfsrtvalidator.api.model.ViewGtfsRtFeedErrorCountModel"/>
     <mapping class="edu.usf.cutr.gtfsrtvalidator.api.model.ViewMessageDetailsModel"/>
+    <mapping class="edu.usf.cutr.gtfsrtvalidator.api.model.ViewIterationErrorsModel"/>
   </session-factory>
 </hibernate-configuration>

--- a/src/main/resources/webroot/css/style.css
+++ b/src/main/resources/webroot/css/style.css
@@ -62,19 +62,45 @@
 }
 
 #feedMessage {
-    height: 500px;
-    width: 550px;
+    height: 550px;
     overflow: auto;
+}
+
+.feed-padding {
+    padding-top: 70px;
 }
 
 #copy-clipboard {
     cursor: pointer;
     position: fixed;
     font-size: 3em;
-    right: 70px;
-    bottom: 30px;
+    left: 600px;
+    top: 550px;
+}
+
+.iteration-issues {
+    padding-top: 20px;
+    height: 500px;
+    overflow: auto;
 }
 
 .modal-title {
     text-align: center;
+}
+
+.feed-padding .content-well {
+    margin: 0;
+    padding-top: 10px;
+}
+
+.each-card {
+    background-color: #ffffff;
+}
+
+.iterations-thead {
+	background-color: rgba(85, 85, 85, 0.62);
+}
+
+.iterations-td {
+	background-color: rgba(85, 85, 85, 0.11);
 }

--- a/src/main/resources/webroot/custom-js/iteration.js
+++ b/src/main/resources/webroot/custom-js/iteration.js
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2017 University of South Florida.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Get all the local data required.
+var urls = localStorage.getItem("gtfsRtFeeds");
+var gtfsRtFeeds = JSON.parse(urls);
+var gtfsRtId = sessionStorage.getItem("gtfsRtId");
+var rowId = sessionStorage.getItem("rowId");
+var iterationId = sessionStorage.getItem("iterationId");
+var timestamp = sessionStorage.getItem("timestamp");
+var occurrence = sessionStorage.getItem("occurrence");
+
+// These variables store data that is needed when showing more and less errors for each error/warning.
+var showMoreErrorList;
+var MAX_ERRORS_TO_DISPLAY = 3;
+var showLessErrorList = {};
+
+var server = window.location.protocol + "//" + window.location.host;
+
+// Get the feedMessage from server for a particular 'iterationId' and display in plain text format to user.
+$.get(server + "/api/gtfs-rt-feed/" + iterationId + "/feedMessage").done(function (data) {
+    var gtfsRtUrl = "";
+    for (gtfsRtFeed in gtfsRtFeeds) {
+        if (gtfsRtFeeds[gtfsRtFeed]["feedId"] == gtfsRtId) {
+            gtfsRtUrl = gtfsRtFeeds[gtfsRtFeed]["url"];
+        }
+    }
+    var jsonFeed = JSON.stringify(data, undefined, 2);
+    document.getElementById("feedMessage").innerHTML = jsonFeed;
+    $("#title-text").text("Iteration " + rowId + " - " + timestamp + " (" + occurrence + ") - " + gtfsRtUrl);
+});
+
+var clipboard = new Clipboard("#clipboard");
+
+clipboard.on('success', function(e) {
+    e.clearSelection();
+    var btn = $(e.trigger);
+    setTooltip(btn,'Copied!');
+    hideTooltip(btn);
+});
+
+clipboard.on('error', function(e) {
+    var btn = $(e.trigger);
+    setTooltip('Failed!');
+    hideTooltip(btn);
+});
+
+// Get the list of errors/warnings and list of their occurrences from server for a particular 'iterationId'.
+$.get(server + "/api/gtfs-rt-feed/" + iterationId + "/iterationErrors").done(function (data) {
+
+    showMoreErrorList = data;
+    var errorCount = 0;
+    var warningCount = 0;
+
+    // Get the correct count of error occurrences to show in text '...and xx more'
+    for (errorListIndex in data) {
+        data[errorListIndex]["errorOccurrences"] = data[errorListIndex]["errorOccurrences"] - MAX_ERRORS_TO_DISPLAY;
+    }
+
+    /*
+     * Form the required number of error/warning cards table structure.
+     * The size of 'data' is the number of error/warning cards required.
+     */
+    var eachCardTemplateScript = $("#error-card-table-template").html();
+    var eachCardTemplate = Handlebars.compile(eachCardTemplateScript);
+    var cardsCompiledHtml = eachCardTemplate(data);
+    $("#error-cards").html(cardsCompiledHtml);
+
+    for (errorListIndex in data) {
+        // Hide '...and xx more' message if occurrences <= 0
+        if (data[errorListIndex]["errorOccurrences"] <= 0) {
+            $(".show-more-" + errorListIndex).hide();
+        }
+        // Calculate the count of errors and warnings.
+        if (data[errorListIndex]["errorId"].startsWith("E")) {
+            errorCount++;
+        } else if (data[errorListIndex]["errorId"].startsWith("W")) {
+            warningCount++;
+        }
+
+        // Fill each error/warning card table data
+        var cardBodyTemplateScript = $("#error-card-body-template").html();
+        var cardBodyTemplate = Handlebars.compile(cardBodyTemplateScript);
+
+        showLessErrorList[errorListIndex] = {};
+
+        /*
+         * At first, we will display less number of rows in each error/warning table.
+         * 'MAX_ERRORS_TO_DISPLAY' is the number of error/warning occurrences to display.
+         * 'showLessErrorList' will store each error occurrences data size to <= 'MAX_ERRORS_TO_DISPLAY'
+         */
+        for (numErrorsIndex in data[errorListIndex]["viewIterationErrorsModelList"]) {
+            if (numErrorsIndex < MAX_ERRORS_TO_DISPLAY) {
+                showLessErrorList[errorListIndex][numErrorsIndex] = data[errorListIndex]["viewIterationErrorsModelList"][numErrorsIndex];
+            }
+        }
+        var bodyCompiledHtml = cardBodyTemplate(showLessErrorList[errorListIndex]);
+        $("#error-card-body-" + errorListIndex).html(bodyCompiledHtml);
+    }
+
+    $("#error-count").text(errorCount);
+    $("#warning-count").text(warningCount);
+});
+
+// On clicking '...and xx more' text, this method will show all the occurrences of that error/warning
+function showEntireList(errorIndex) {
+    var cardDataTemplateScript = $("#error-card-body-template").html();
+    var cardDataTemplate = Handlebars.compile(cardDataTemplateScript);
+    var dataCompiledHtml = cardDataTemplate(showMoreErrorList[errorIndex]["viewIterationErrorsModelList"]);
+
+    $("#error-card-body-" + errorIndex).html(dataCompiledHtml);
+
+    $(".show-more-" + errorIndex).hide();
+    $(".show-less-" + errorIndex).show();
+}
+
+// On clicking 'show less' text, this method will show 'MAX_ERRORS_TO_DISPLAY' occurrences of that error/warning
+function showLessErrors(errorIndex) {
+    var cardBodyTemplateScript = $("#error-card-body-template").html();
+    var cardBodyTemplate = Handlebars.compile(cardBodyTemplateScript);
+    var bodyCompiledHtml = cardBodyTemplate(showLessErrorList[errorIndex]);
+
+    $("#error-card-body-" + errorIndex).html(bodyCompiledHtml);
+
+    $(".show-less-" + errorIndex).hide();
+    $(".show-more-" + errorIndex).show();
+}
+
+function setTooltip(btn,message) {
+    btn.attr('data-original-title', message)
+        .tooltip('show');
+}
+
+function hideTooltip(btn) {
+    setTimeout(function() {
+        btn.tooltip('hide');
+    }, 1000);
+}

--- a/src/main/resources/webroot/custom-js/monitoring.js
+++ b/src/main/resources/webroot/custom-js/monitoring.js
@@ -293,41 +293,12 @@ function updatePaginationInfo(logOrSumary, index, paginationInfo) {
     }
 }
 
-function showFeedMessage(rowId, iterationId, timestamp, occurrence) {
-    $.get(server + "/api/gtfs-rt-feed/" + iterationId + "/feedMessage").done(function (data) {
-        var jsonFeed = JSON.stringify(data, undefined, 2);
-        var feedTemplateScript = $("#gtfs-rt-feed-message").html();
-        $(".feedMessageDialog").html(feedTemplateScript);
-        document.getElementById("feedMessage").innerHTML = jsonFeed;
-        $("#title-text").text("Iteration " + rowId + " - " + timestamp + " (" + occurrence + ")");
-        $("#feed-message-modal").modal();
-    });
-
-    var clipboard = new Clipboard("#clipboard");
-
-    clipboard.on('success', function(e) {
-        e.clearSelection();
-        var btn = $(e.trigger);
-        setTooltip(btn,'Copied!');
-        hideTooltip(btn);
-    });
-
-    clipboard.on('error', function(e) {
-        var btn = $(e.trigger);
-        setTooltip('Failed!');
-        hideTooltip(btn);
-    });
-}
-
-function setTooltip(btn,message) {
-    btn.attr('data-original-title', message)
-        .tooltip('show');
-}
-
-function hideTooltip(btn) {
-    setTimeout(function() {
-        btn.tooltip('hide');
-    }, 1000);
+function storeFeedMessageDetails(gtfsRtId, rowId, iterationId, timestamp, occurrence) {
+    sessionStorage.setItem("gtfsRtId", gtfsRtId);
+    sessionStorage.setItem("rowId", rowId);
+    sessionStorage.setItem("iterationId", iterationId);
+    sessionStorage.setItem("timestamp", timestamp);
+    sessionStorage.setItem("occurrence", occurrence);
 }
 
 $(document).ready(function(){

--- a/src/main/resources/webroot/iteration.html
+++ b/src/main/resources/webroot/iteration.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Iteration details</title>
+    <link rel="stylesheet" href="css/bootstrap.min.css">
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <div class="navbar navbar-default navbar-fixed-top">
+        <div class="container">
+            <div class="navbar-header">
+                <span class="navbar-brand" id="title-text">
+                </span>
+            </div>
+        </div>
+    </div>
+
+    <div class="container">
+        <div class="row">
+            <div class="col-md-6 feed-padding">
+                <pre id="feedMessage"></pre>
+                <div class="pull-left" id="copy-clipboard">
+                    <span class="glyphicon glyphicon-copy" data-placement="top" data-trigger="click" id="clipboard" data-clipboard-target="#feedMessage">
+                    </span>
+                </div>
+            </div>
+
+
+            <div class="col-md-6 feed-padding">
+                <div class="well content-well ">
+                    <span class="info-text" id="error-count">0</span>
+                    &nbsperror(s),
+                    <span class="info-text" id="warning-count">0</span>
+                    &nbspwarning(s)
+                </div>
+
+                <div class="well content-well iteration-issues">
+                    <div id="error-cards">
+                    </div>
+                </div>
+            </div>
+        </div>
+
+    </div>
+
+    <script src="js/jquery-2.1.4.min.js"></script>
+    <script src="js/bootstrap.min.js"></script>
+    <script src="js/clipboard.min.js"></script>
+    <script src="js/handlebars.js"></script>
+
+    <script id="error-each-card-template" type="text/x-handlebars-template">
+        {{#each this}}
+        <div id="error-card-{{@index}}">
+        </div>
+        {{/each}}
+    </script>
+
+    <script id="error-card-table-template" type="text/x-handlebars-template">
+        {{#each this}}
+        <div class="well each-card">
+            <h4>{{errorId}} - {{title}}</h4>
+            <hr/>
+            <table class="table">
+                <thead class="iterations-thead">
+                <tr>
+                    <th>OccurrenceId</th>
+                    <th>Summary</th>
+                </tr>
+                </thead>
+                <tbody id="error-card-body-{{@index}}">
+                </tbody>
+            </table>
+            <div>
+                <a class="show-more-{{@index}}" href="#" onclick="showEntireList({{@index}}); return false;">...and {{errorOccurrences}} more</a>
+            </div>
+            <div>
+                <a class="show-less-{{@index}}" href="#" onclick="showLessErrors({{@index}}); return false;" style="display: none;">...show less</a>
+            </div>
+        </div>
+        {{/each}}
+    </script>
+
+    <script id="error-card-body-template" type="text/x-handlebars-template">
+        {{#each this}}
+        <tr>
+            <td class="iterations-td">{{rowId}}</td>
+            <td class="iterations-td">{{occurrencePrefix}} {{occurrenceSuffix}}</td>
+        </tr>
+        {{/each}}
+    </script>
+
+    <script src="custom-js/iteration.js"></script>
+</body>
+</html>

--- a/src/main/resources/webroot/monitoring.html
+++ b/src/main/resources/webroot/monitoring.html
@@ -101,7 +101,6 @@
 
     </div>
 
-    <div class="feedMessageDialog"> </div>
 </div>
 <!-- /.container -->
 <!-- script references -->
@@ -204,7 +203,7 @@
 <script id="feed-monitor-log-row-template" type="text/x-handlebars-template">
     {{#each this}}
     <tr>
-        <td><a href="#" onclick="showFeedMessage({{rowId}}, {{iterationId}}, '{{formattedTimestamp}}', {{occurrence}}); return false;">{{rowId}}</a></td>
+        <td><a href="iteration.html" target="_blank" onclick="storeFeedMessageDetails({{gtfsRtId}}, {{rowId}}, {{iterationId}}, '{{formattedTimestamp}}', {{occurrence}})">{{rowId}}</a></td>
         <td>{{id}}</td>
         <td>{{title}}</td>
 
@@ -212,26 +211,6 @@
         <td title="Time zone: {{timeZone}}">{{formattedTimestamp}} ({{occurrence}})</td>
     </tr>
     {{/each}}
-</script>
-
-<script id="gtfs-rt-feed-message" type="text/x-handlebars-template">
-    <div id="feed-message-modal" class="modal fade" role="dialog">
-        <div class="modal-dialog" role="document">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                    <h4 class="modal-title" id="title-text"></h4>
-                </div>
-                <div class="modal-body">
-                    <pre id="feedMessage"></pre>
-                    <div class="pull-left" id="copy-clipboard">
-                        <span class="glyphicon glyphicon-copy" data-placement="top" data-trigger="click" id="clipboard" data-clipboard-target="#feedMessage">
-                        </span>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
 </script>
 
 <script src="custom-js/monitoring.js"></script>


### PR DESCRIPTION

**Summary:**

When an iteration id link is clicked, it displays all the iteration errors/warnings and feed message text in new window. 
Fixes #139 .

**Expected behavior:** 

Here are the screenshots of iteration details.

![image](https://cloud.githubusercontent.com/assets/17164961/25510499/8a065144-2b8e-11e7-8fa2-58f9898ae979.png)


![image](https://cloud.githubusercontent.com/assets/17164961/25510488/6ee38116-2b8e-11e7-9242-287a79e08502.png)



Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "Fix #issue - short description of fix and changes"
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
