### PR TITLE
Fix #148 - Removed extra trailing spaces in GTFS feed URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ deploy:
   # builds of your repo's master branch (e.g., after you merge a PR).
   provider: s3
   # You can refer to environment variables from Travis repo settings!
-  access_key_id: $AWS_ACCESS_KEY_ID
-  secret_access_key: $AWS_SECRET_ACCESS_KEY
+  access_key_id: $ARTIFACTS_KEY
+  secret_access_key: $ARTIFACTS_SECRET
   # Name of the S3 bucket to which your site should be uploaded.
   bucket: $ARTIFACTS_BUCKET
   # Prevent Travis from deleting your built site so it can be uploaded.

--- a/src/main/resources/webroot/css/style.css
+++ b/src/main/resources/webroot/css/style.css
@@ -78,3 +78,13 @@
 .modal-title {
     text-align: center;
 }
+
+::-ms-clear {
+  display: none;
+}
+
+.form-control-clear {
+  z-index: 10;
+  pointer-events: auto;
+  cursor: pointer;
+}

--- a/src/main/resources/webroot/custom-js/index.js
+++ b/src/main/resources/webroot/custom-js/index.js
@@ -26,10 +26,12 @@ function addInput(){
         var count = (counter + 1);
         var HTMLString;
 
-        HTMLString = "<div class=\"form-group\"> <label for=\"gtfsrt-feed-"+ count +"\">GTFS-Realtime Feed "+ count +"</label>";
-        HTMLString += "<input class=\"form-control\" name=\"gtfsrt-feed-"+ count+ "\"/></div>";
+        HTMLString = "<div class=\"form-group has-feedback has-clear\"> <label for=\"gtfsrt-feed-"+ count +"\">GTFS-Realtime Feed "+ count +"</label>";
+        HTMLString += "<input type=\"text\" class=\"form-control\" name=\"gtfsrt-feed-"+ count+ "\"/>";
+        HTMLString += "<span class=\"form-control-clear glyphicon glyphicon-remove form-control-feedback hidden\"></span> </div>"
         newdiv.innerHTML = HTMLString;
         $("#dynamicInput").append(newdiv);
+        removeTextInput();
         counter++;
     }
 }
@@ -46,10 +48,16 @@ function removeInput(){
 //Checking if there is text on both GTFS and GTFS-RT fields
 var gtfsURLField = $('#gtfsrt-feed-1');
 var gtfsrtURLField = $('#gtfs');
+// Adding clear text field functionality to each of input type='text'
+removeTextInput();
 var $submit = $('input[type="submit"]');
 var reset = $('input[type="reset"]');
 reset.on('click', disableSubmit);
-$submit.prop('disabled', true);
+/*
+ * 'checkStatus' method call here ensures submit button is disabled/enabled based on text input values
+ *   when we come back from loading.html to welcome page.
+ */
+checkStatus();
 
 gtfsURLField.bind('input', checkStatus);
 gtfsrtURLField.bind('input', checkStatus);
@@ -61,4 +69,30 @@ function checkStatus() {
 
 function disableSubmit() {
     $submit.prop('disabled', true);
+    $('.form-control-clear').toggleClass('hidden', true);
 }
+
+/*
+ * Make visible the remove glyphicon in input text field on entering text in it
+ *  and upon clicking the remove glyphicon, clears the input text.
+ */
+function removeTextInput() {
+    $('.has-clear input[type="text"]').on('input propertychange', function() {
+      var $this = $(this);
+      var visible = Boolean($this.val());
+      $this.siblings('.form-control-clear').toggleClass('hidden', !visible);
+    }).trigger('propertychange');
+
+    $('.form-control-clear').click(function() {
+      $(this).siblings('input[type="text"]').val('')
+        .trigger('propertychange').focus();
+      checkStatus();
+    });
+}
+
+// Trim spaces for each of input type="text", before submitting the form.
+$('input[type="submit"]').click(function () {
+    $('input[type="text"]').each(function(){
+      this.value=$(this).val().trim();
+    })
+});

--- a/src/main/resources/webroot/index.html
+++ b/src/main/resources/webroot/index.html
@@ -91,9 +91,10 @@
                                 <hr/>
 
                                 <div id="dynamicInput">
-                                    <div class="form-group">
+                                    <div class="form-group has-feedback has-clear">
                                         <label for="gtfsrt-feed-1">GTFS-Realtime Feed 1</label>
-                                        <input class="form-control" name="gtfsrt-feed-1" id="gtfsrt-feed-1"/>
+                                        <input type="text" class="form-control" name="gtfsrt-feed-1" id="gtfsrt-feed-1"/>
+                                        <span class="form-control-clear glyphicon glyphicon-remove form-control-feedback hidden"></span>
                                     </div>
                                 </div>
                                 <div class="row">
@@ -116,9 +117,10 @@
                             <div class="well">
                                 <h4>Step 2: add your GTFS feed</h4>
                                 <hr/>
-                                <div class="form-group">
+                                <div class="form-group has-feedback has-clear">
                                     <label for="gtfs">GTFS feed</label>
-                                    <input class="form-control" name="gtfs" id="gtfs"/>
+                                    <input type="text" class="form-control" name="gtfs" id="gtfs"/>
+                                    <span class="form-control-clear glyphicon glyphicon-remove form-control-feedback hidden"></span>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
**Summary:**

Fixes #148. 
For each text field, remove text field button is added that is hidden until some text is entered into text. Upon clicking on it, it clears the input text.

**Expected behavior:** 

The application shouldn't fail if entered GTFS feed URL contains extra trailing spaces.

Screenshots:

![image](https://cloud.githubusercontent.com/assets/17164961/25538864/619d735c-2c12-11e7-8ecb-2e88a0e61305.png)



Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "Fix #issue - short description of fix and changes"
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
