### PR TITLE
Fix #175 - Clock doesn't display correct minutes for long running timer

### DIFF
--- a/src/main/resources/webroot/custom-js/monitoring.js
+++ b/src/main/resources/webroot/custom-js/monitoring.js
@@ -227,6 +227,7 @@ function getTimeElapsed() {
     var hours = Math.floor(minutes / 60);
 
     var sec = TrimSecondsMinutes(seconds);
+    var min = TrimSecondsMinutes(minutes);
 
     function TrimSecondsMinutes(elapsed) {
         if (elapsed >= 60)
@@ -234,7 +235,7 @@ function getTimeElapsed() {
         return elapsed;
     }
 
-    $("#time-elapsed").text(hours + "h " + minutes + "m " + sec + "s");
+    $("#time-elapsed").text(hours + "h " + min + "m " + sec + "s");
 }
 
 //Call time elapsed to update the clock evey second


### PR DESCRIPTION
**Summary:**

Fixes #175 . 

**Expected behavior:** 

Timer minutes should not exceed 60 after running the application for more than an hour.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "Fix #issue - short description of fix and changes"
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
