### PR TITLE
Fix #181 - Correctly getting the web resources from packaged jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <jetty-version>9.2.6.v20141205</jetty-version>
+        <jetty-version>9.3.0.v20150612</jetty-version>
         <gtfs_realtime_api_version>1.1.0</gtfs_realtime_api_version>
     </properties>
 

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/Main.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/Main.java
@@ -25,12 +25,13 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.glassfish.jersey.servlet.ServletContainer;
 import org.slf4j.LoggerFactory;
 
 public class Main {
     private static final org.slf4j.Logger _log = LoggerFactory.getLogger(Main.class);
 
-    static String BASE_RESOURCE = "./target/classes/webroot";
+    static String BASE_RESOURCE = Main.class.getResource("/webroot").toExternalForm();
     private static String PORT_NUMBER_OPTION = "port";
 
     public static void main(String[] args) throws InterruptedException, ParseException {
@@ -49,7 +50,7 @@ public class Main {
         context.addServlet(GetFeedJSON.class, "/getFeed");
         context.addServlet(DefaultServlet.class, "/");
 
-        ServletHolder jerseyServlet = context.addServlet(org.glassfish.jersey.servlet.ServletContainer.class, "/api/*");
+        ServletHolder jerseyServlet = context.addServlet(ServletContainer.class, "/api/*");
         jerseyServlet.setInitOrder(1);
         jerseyServlet.setInitParameter("jersey.config.server.provider.classnames", "org.glassfish.jersey.moxy.json.MoxyJsonFeature");
         jerseyServlet.setInitParameter("jersey.config.server.provider.packages", "edu.usf.cutr.gtfsrtvalidator.api.resource");


### PR DESCRIPTION
**Summary:**

*  **Pom.xml** is only modified to get the latest jetty versions. It does not have any effect on this issue.
*  **Main.java** modifications ensures that web app resources are correctly accessed from packaged jar.

Fixes #181.

**Expected behavior:** 

Now the JAR file generated by Travis and uploaded to S3 should work as expected without any web resources accessing errors.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "Fix #issue - short description of fix and changes"
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
