### PR TITLE
Add build number precision to version number

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ deploy:
   skip_cleanup: true
   acl: public_read
   # Path to build artifacts
-  local_dir: $HOME/.m2/repository/edu/usf/cutr/gtfs-rt-validator/1.0-SNAPSHOT
+  local_dir: $HOME/.m2/repository/edu/usf/cutr/gtfs-rt-validator/1.0.0-SNAPSHOT
   upload_dir: travis_builds
   # Set the Cache-Control header.
   cache_control: "max-age=21600"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Alternately, you can load the project as Maven project in an IDE like [IntelliJ]
 
 From the command-line, run: 
 
-`java -jar target/gtfs-rt-validator-1.0-SNAPSHOT.jar`
+`java -jar target/gtfs-rt-validator-1.0.0-SNAPSHOT.jar`
 
 You should see some output, and a message saying `Go to http://localhost:8080 in your browser`. 
 
@@ -65,7 +65,7 @@ If you'd like to change the logging level, for example to see all debug statemen
  
  Port `8080` is used by default.  If you'd like to change the port number (e.g., port `80`), you can use the command line parameter `-port 80`:
  
- `java -jar target/gtfs-rt-validator-1.0-SNAPSHOT.jar -port 80`
+ `java -jar target/gtfs-rt-validator-1.0.0-SNAPSHOT.jar -port 80`
  
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>edu.usf.cutr</groupId>
     <artifactId>gtfs-rt-validator</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
 
     <properties>
         <jetty-version>9.3.0.v20150612</jetty-version>


### PR DESCRIPTION
**Summary:**

@mohangandhiGH Just a heads up - I'm adding a build/patch number to our version number, so the new version is `1.0.0-SNAPSHOT` instead of `1.0.-SNAPSHOT`.