### PR TITLE
Fix #114 - Loading static GTFS validation report - Multiple web resources

### DIFF
--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsFeed.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsFeed.java
@@ -62,7 +62,7 @@ public class GtfsFeed {
     private static final org.slf4j.Logger _log = LoggerFactory.getLogger(GtfsFeed.class);
 
     private static final int BUFFER_SIZE = 4096;
-    private static final String jsonFilePath = "target"+File.separator+"classes"+File.separator+"webroot";
+    private static final String jsonFilePath = "classes"+File.separator+"webroot";
     public static Map<Integer, GtfsDaoImpl> GtfsDaoMap = new ConcurrentHashMap<>();
 
     //DELETE {id} remove feed with the given id
@@ -146,7 +146,7 @@ public class GtfsFeed {
             // If file digest are equal, check whether validated json file exists
             if (MessageDigest.isEqual(newChecksum, oldChecksum)) {
                 _log.info("GTFS data hasn't changed since last execution");
-                String projectPath = new GetFile().getJarLocation().getParentFile().getParentFile().getAbsolutePath();
+                String projectPath = new GetFile().getJarLocation().getParentFile().getAbsolutePath();
                 if(new File(projectPath +File.separator+ jsonFilePath +File.separator+ fileName + "_out.json").exists())
                     canReturn = true;
             } else {
@@ -187,7 +187,7 @@ public class GtfsFeed {
         JsonSerializer serializer = new JsonSerializer(results);
         //get the location of the executed jar file
         GetFile jarInfo = new GetFile();
-        String saveDir = jarInfo.getJarLocation().getParentFile().getParentFile().getAbsolutePath();
+        String saveDir = jarInfo.getJarLocation().getParentFile().getAbsolutePath();
         saveFilePath = saveDir + File.separator + jsonFilePath + File.separator + fileName + "_out.json";
         try {
             serializer.serializeToFile(new File(saveFilePath));


### PR DESCRIPTION

**Summary:**

When we use the jar file uploaded to Amazon S3 (generated by Travis build), it does not have any build folders. So the json output generated after static GTFS data is validated, cannot be packaged into jar. 

Therefore, to be independent of build folders and to access validation output, added an other web resource path for static GTFS validation json output directory '.../jar-location-directory/classes/webroot'.

Fixes #114. Related to issue #181.  

**Expected behavior:** 

Now the static GTFS validation report loads successfully.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "Fix #issue - short description of fix and changes"
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
