### PR TITLE
WIP #199 - Initial work towards optimizing trip shape building

### DIFF
--- a/src/main/resources/simplelogger.properties
+++ b/src/main/resources/simplelogger.properties
@@ -5,4 +5,4 @@ handlers = org.eclipse.jetty.demo.SystemOutHandler
 org.slf4j.simpleLogger.log.org.eclipse.jetty = WARN
 org.slf4j.simpleLogger.log.org.hibernate = WARN
 org.slf4j.simpleLogger.log.org.onebusaway = WARN
-org.slf4j.simpleLogger.defaultLogLevel=INFO
+org.slf4j.simpleLogger.defaultLogLevel=DEBUG


### PR DESCRIPTION
**Please do not merge**

* Don't build shapes for trips with calendar.txt service that does not include the current date.  However, this is problematic if the validator is run for more than 24 hours on a feed (as we wouldn't compare against new service starting tomorrow), and doesn't currently handle agencies that express all service in calendar_dates.txt instead of calendar.txt.  How to fix??

This cuts MBTA metadata generation time from around 104 seconds to around 38 seconds.