### PR TITLE
Fix #134 - Use the GTFS URL as the unique file name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>
-        <jetty-version>9.3.0.v20150612</jetty-version>
+        <jetty-version>9.4.5.v20170502</jetty-version>
         <gtfs_realtime_api_version>1.1.0</gtfs_realtime_api_version>
     </properties>
 
@@ -53,6 +53,12 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>apache-jstl</artifactId>
+            <version>${jetty-version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
             <version>${jetty-version}</version>
         </dependency>
 

--- a/src/main/resources/webroot/custom-js/loading.js
+++ b/src/main/resources/webroot/custom-js/loading.js
@@ -150,8 +150,8 @@ function monitorGtfsRtFeeds(gtfsrtUrlList, gtfsFeedId) {
 //Download the provided GTFS feed
 function downloadGTFSFeed() {
     var paramVal = getUrlParameter("gtfs");
+    localStorage.setItem("gtfsFileName", paramVal);
     paramVal = decodeURIComponent(paramVal);
-    localStorage.setItem("gtfsFileName", paramVal.split('/').pop().split('.')[0]);
 
     var progressID = "#gtfs-progress";
 

--- a/src/main/resources/webroot/custom-js/monitoring.js
+++ b/src/main/resources/webroot/custom-js/monitoring.js
@@ -65,7 +65,7 @@ function loadGtfsErrorCount(gtfsFeedId) {
     $.get(server + "/api/gtfs-feed/" + gtfsFeedId + "/errorCount").done(function (data)  {
         $("#gtfs-error").text(data["errorCount"]);
 
-        var linkToReport = '<a href = ' + localStorage.getItem("reportURL") + localStorage.getItem("gtfsFileName") + '_out.json target="_blank">' + data["errorCount"] + ' error(s)/warning(s)</a>';
+        var linkToReport = '<a href = ' + localStorage.getItem("reportURL") + encodeURIComponent(encodeURIComponent(localStorage.getItem("gtfsFileName"))) + '_out.json target="_blank">' + data["errorCount"] + ' error(s)/warning(s)</a>';
         $(".GTFS-report-link").html(linkToReport);
     });
 }


### PR DESCRIPTION
* Instead of using just the zip file name to identify a feed, this patch changes to using a URL-encoded version of the entire GTFS URL as the feed name.  This eliminates potential collisions between two feeds that have the same zip file name (e.g., google_transit.zip) but are hosted at two different URLs.
* I was getting 404 errors when trying to read the URL-encoded file name from "../webroot", so I bumped the Jetty version (and then got a ClassNotFoundException, and had to add a new "jetty-server" dependency in pom.xml), and that seemed to fix the issue.  Now the GTFS URL is encoded once internally, and then in the site Javascript it's encoded-twice to retrieve the validation report.

@mohangandhiGH Would you be willing to review this?  It should be fairly straightforward, I just want to make sure I didn't break anything else related to the GTFS storage/validation.