### PR TITLE
Fix #201, 206, 209 - New rules E030, E031, E032, E033 - Alert informed_entity validation

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -30,6 +30,10 @@ Rules are declared in the [`ValidationRules` class](https://github.com/CUTR-at-U
 | [E027](#E027) | Invalid vehicle `bearing`
 | [E028](#E028) | Vehicle `position` outside agency coverage area
 | [E029](#E029) | Vehicle `position` far from trip shape
+| [E030](#E030) | GTFS-rt alert `trip_id` does not belong to GTFS-rt alert `route_id` in GTFS `trips.txt`
+| [E031](#E031) | Alert `informed_entity.route_id` does not match `informed_entity.trip.route_id`
+| [E032](#E032) | Alert does not have an `informed_entity`
+| [E033](#E033) | Alert `informed_entity` does not have any specifiers
 
 ### Table of Warnings
 
@@ -254,6 +258,44 @@ Buffer is defined by `GtfsMetadata.TRIP_BUFFER_METERS`, and is currently 200 met
 * [GTFS shapes.txt](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#shapestxt)
 * [vehicle.position](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-position)
 * [alert.effect.DETOUR](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#enum-effect)
+
+<a name="E030"/>
+
+### E030 - GTFS-rt alert `trip_id` does not belong to GTFS-rt alert `route_id` in GTFS `trips.txt`
+
+The GTFS-rt `alert.informed_entity.trip.trip_id` should belong to the specified GTFS-rt `alert.informed_entity.route_id` in GTFS `trips.txt`.
+
+#### References:
+* [alert.informed_entity](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-entityselector)
+* [GTFS trips.txt](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#tripstxt)
+
+<a name="E031"/>
+
+### E031 - Alert `informed_entity.route_id` does not match `informed_entity.trip.route_id`
+
+The `alert.informed_entity.trip.route_id` should be the same as the specified `alert.informed_entity.route_id`.
+
+#### References:
+* [alert.informed_entity](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-entityselector)
+* [alert.informed_entity.trip](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-tripdescriptor)
+
+<a name="E032"/>
+
+### E032 - Alert does not have an `informed_entity`
+
+All alerts must have at least one `informed_entity`.
+
+#### References:
+* [alert.informed_entity](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-entityselector)
+
+<a name="E033"/>
+
+### E033 - Alert `informed_entity` does not have any specifiers
+
+Alert `informed_entity` should have at least one specified value (`route_id`, `trip_id`, `stop_id`, etc) to which the alert applies.
+
+#### References:
+* [alert.informed_entity](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-entityselector)
 
 # Warnings
 

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/ValidationRules.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/ValidationRules.java
@@ -166,4 +166,20 @@ public class ValidationRules {
     public static final ValidationRule E029 = new ValidationRule("E029", "ERROR", "Vehicle position far from trip shape",
             "The vehicle position should be within a certain distance of the GTFS shapes.txt data for the current trip unless there is a Service Alert with the Effect of DETOUR for this trip_id.",
             "- vehicle should be near trip shape or on DETOUR");
+
+    public static final ValidationRule E030 = new ValidationRule("E030", "ERROR", "GTFS-rt alert trip_id does not belong to GTFS-rt alert route_id in GTFS trips.txt",
+            "The alert.informed_entity.trip.trip_id should belong to the specified alert.informed_entity.route_id in GTFS trips.txt",
+            "- informed_entity.route_id must match GTFS data");
+
+    public static final ValidationRule E031 = new ValidationRule("E031", "ERROR", "Alert informed_entity.route_id does not match informed_entity.trip.route_id",
+            "The alert.informed_entity.trip.route_id should be the same as the specified alert-informed_entity.route_id.",
+            "- routes_ids must be the same");
+
+    public static final ValidationRule E032 = new ValidationRule("E032", "ERROR", "Alert does not have an informed_entity",
+            "All alerts must have at least one informed_entity.",
+            "- alerts must have at least one informed_entity");
+
+    public static final ValidationRule E033 = new ValidationRule("E033", "ERROR", "Alert informed_entity does not have any specifiers",
+            "Alert informed_entity should have at least one specified value (route_id, trip_id, stop_id, etc) to which the alert applies.",
+            "- alert informed_entity should have at least one specified value");
 }

--- a/src/test/java/edu/usf/cutr/gtfsrtvalidator/test/feeds/combined/TripUpdateVehiclePositionTest.java
+++ b/src/test/java/edu/usf/cutr/gtfsrtvalidator/test/feeds/combined/TripUpdateVehiclePositionTest.java
@@ -470,4 +470,270 @@ public class TripUpdateVehiclePositionTest extends FeedMessageTest {
 
         clearAndInitRequiredFeedFields();
     }
+
+    /**
+     * E030 - GTFS-rt alert trip_id does not belong to GTFS-rt alert route_id in GTFS trips.txt
+     */
+    @Test
+    public void testE030() {
+        TripDescriptorValidator tripDescriptorValidator = new TripDescriptorValidator();
+
+        // In bullrunner-gtfs.zip trips.txt, trip_id=1 belongs to route_id=A
+        GtfsRealtime.TripDescriptor.Builder tripDescriptorBuilder = GtfsRealtime.TripDescriptor.newBuilder();
+        GtfsRealtime.EntitySelector.Builder entitySelectorBuilder = GtfsRealtime.EntitySelector.newBuilder();
+
+        // Don't set route_id or trip_id (but set stop_id - we need at least one specifier) - no errors
+        entitySelectorBuilder.setStopId("1234");
+        entitySelectorBuilder.setTrip(tripDescriptorBuilder.build());
+        alertBuilder.addInformedEntity(entitySelectorBuilder.build());
+        feedEntityBuilder.setAlert(alertBuilder.build());
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        results = tripDescriptorValidator.validate(MIN_POSIX_TIME, bullRunnerGtfs, bullRunnerGtfsMetadata, feedMessageBuilder.build(), null);
+        TestUtils.assertResults(ValidationRules.E030, results, 0);
+
+        // Set trip_id but not route_id - no errors
+        tripDescriptorBuilder.setTripId("1");
+        entitySelectorBuilder.setTrip(tripDescriptorBuilder.build());
+        alertBuilder.clearInformedEntity();
+        alertBuilder.addInformedEntity(entitySelectorBuilder.build());
+        feedEntityBuilder.setAlert(alertBuilder.build());
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        results = tripDescriptorValidator.validate(MIN_POSIX_TIME, bullRunnerGtfs, bullRunnerGtfsMetadata, feedMessageBuilder.build(), null);
+        TestUtils.assertResults(ValidationRules.E030, results, 0);
+
+        // Set route_id but not trip_id - no errors
+        tripDescriptorBuilder.clear();
+        entitySelectorBuilder.setRouteId("A");
+        entitySelectorBuilder.setTrip(tripDescriptorBuilder.build());
+        alertBuilder.clearInformedEntity();
+        alertBuilder.addInformedEntity(entitySelectorBuilder.build());
+        feedEntityBuilder.setAlert(alertBuilder.build());
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        results = tripDescriptorValidator.validate(MIN_POSIX_TIME, bullRunnerGtfs, bullRunnerGtfsMetadata, feedMessageBuilder.build(), null);
+        TestUtils.assertResults(ValidationRules.E030, results, 0);
+
+        // Set route_id and trip_id to correct values according to GTFS trips.txt - no errors
+        tripDescriptorBuilder.setTripId("1");
+        entitySelectorBuilder.setRouteId("A");
+        entitySelectorBuilder.setTrip(tripDescriptorBuilder.build());
+        alertBuilder.clearInformedEntity();
+        alertBuilder.addInformedEntity(entitySelectorBuilder.build());
+        feedEntityBuilder.setAlert(alertBuilder.build());
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        results = tripDescriptorValidator.validate(MIN_POSIX_TIME, bullRunnerGtfs, bullRunnerGtfsMetadata, feedMessageBuilder.build(), null);
+        TestUtils.assertResults(ValidationRules.E030, results, 0);
+
+        // Set route_id to something other than the correct value ("A") - 1 error
+        tripDescriptorBuilder.setTripId("1");
+        entitySelectorBuilder.setRouteId("B");
+        entitySelectorBuilder.setTrip(tripDescriptorBuilder.build());
+        alertBuilder.clearInformedEntity();
+        alertBuilder.addInformedEntity(entitySelectorBuilder.build());
+        feedEntityBuilder.setAlert(alertBuilder.build());
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        results = tripDescriptorValidator.validate(MIN_POSIX_TIME, bullRunnerGtfs, bullRunnerGtfsMetadata, feedMessageBuilder.build(), null);
+        TestUtils.assertResults(ValidationRules.E030, results, 1);
+
+        clearAndInitRequiredFeedFields();
+    }
+
+    /**
+     * E031 - Alert informed_entity.route_id does not match informed_entity.trip.route_id
+     */
+    @Test
+    public void testE031() {
+        TripDescriptorValidator tripDescriptorValidator = new TripDescriptorValidator();
+
+        // In bullrunner-gtfs.zip routes.txt, route_id=A is a valid route
+        GtfsRealtime.TripDescriptor.Builder tripDescriptorBuilder = GtfsRealtime.TripDescriptor.newBuilder();
+        GtfsRealtime.EntitySelector.Builder entitySelectorBuilder = GtfsRealtime.EntitySelector.newBuilder();
+
+        // Don't set either route_id (but set stop_id - we need at least one specifier) - no errors
+        entitySelectorBuilder.setStopId("1234");
+        entitySelectorBuilder.setTrip(tripDescriptorBuilder.build());
+        alertBuilder.addInformedEntity(entitySelectorBuilder.build());
+        feedEntityBuilder.setAlert(alertBuilder.build());
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        results = tripDescriptorValidator.validate(MIN_POSIX_TIME, bullRunnerGtfs, bullRunnerGtfsMetadata, feedMessageBuilder.build(), null);
+        TestUtils.assertResults(ValidationRules.E031, results, 0);
+
+        // Set informed_entity.route_id but not informed_entity.trip.route_id - no errors
+        entitySelectorBuilder.setRouteId("A");
+        entitySelectorBuilder.setTrip(tripDescriptorBuilder.build());
+        alertBuilder.clearInformedEntity();
+        alertBuilder.addInformedEntity(entitySelectorBuilder.build());
+        feedEntityBuilder.setAlert(alertBuilder.build());
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        results = tripDescriptorValidator.validate(MIN_POSIX_TIME, bullRunnerGtfs, bullRunnerGtfsMetadata, feedMessageBuilder.build(), null);
+        TestUtils.assertResults(ValidationRules.E031, results, 0);
+
+        // Set informed_entity.trip.route_id but not informed_entity.route_id - no errors
+        tripDescriptorBuilder.setRouteId("A");
+        entitySelectorBuilder.clear();
+        entitySelectorBuilder.setTrip(tripDescriptorBuilder.build());
+        alertBuilder.clearInformedEntity();
+        alertBuilder.addInformedEntity(entitySelectorBuilder.build());
+        feedEntityBuilder.setAlert(alertBuilder.build());
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        results = tripDescriptorValidator.validate(MIN_POSIX_TIME, bullRunnerGtfs, bullRunnerGtfsMetadata, feedMessageBuilder.build(), null);
+        TestUtils.assertResults(ValidationRules.E031, results, 0);
+
+        // Set informed_entity.trip.route_id and informed_entity.route_id to the same values - no errors
+        tripDescriptorBuilder.setRouteId("A");
+        entitySelectorBuilder.setRouteId("A");
+        entitySelectorBuilder.setTrip(tripDescriptorBuilder.build());
+        alertBuilder.clearInformedEntity();
+        alertBuilder.addInformedEntity(entitySelectorBuilder.build());
+        feedEntityBuilder.setAlert(alertBuilder.build());
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        results = tripDescriptorValidator.validate(MIN_POSIX_TIME, bullRunnerGtfs, bullRunnerGtfsMetadata, feedMessageBuilder.build(), null);
+        TestUtils.assertResults(ValidationRules.E031, results, 0);
+
+        // Set informed_entity.trip.route_id and informed_entity.route_id to they don't match - 1 error
+        tripDescriptorBuilder.setRouteId("A");
+        entitySelectorBuilder.setRouteId("B");
+        entitySelectorBuilder.setTrip(tripDescriptorBuilder.build());
+        alertBuilder.clearInformedEntity();
+        alertBuilder.addInformedEntity(entitySelectorBuilder.build());
+        feedEntityBuilder.setAlert(alertBuilder.build());
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        results = tripDescriptorValidator.validate(MIN_POSIX_TIME, bullRunnerGtfs, bullRunnerGtfsMetadata, feedMessageBuilder.build(), null);
+        TestUtils.assertResults(ValidationRules.E031, results, 1);
+
+        clearAndInitRequiredFeedFields();
+    }
+
+    /**
+     * E032 - Alert does not have an informed_entity
+     */
+    @Test
+    public void testE032() {
+        TripDescriptorValidator tripDescriptorValidator = new TripDescriptorValidator();
+
+        GtfsRealtime.EntitySelector.Builder entitySelectorBuilder = GtfsRealtime.EntitySelector.newBuilder();
+
+        // Don't set an informed_entity - 1 error
+        feedEntityBuilder.setAlert(alertBuilder.build());
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        results = tripDescriptorValidator.validate(MIN_POSIX_TIME, bullRunnerGtfs, bullRunnerGtfsMetadata, feedMessageBuilder.build(), null);
+        TestUtils.assertResults(ValidationRules.E032, results, 1);
+
+        // Add an informed_entity with at least one specifier - no errors
+        entitySelectorBuilder.setRouteId("A");
+        alertBuilder.addInformedEntity(entitySelectorBuilder.build());
+        feedEntityBuilder.setAlert(alertBuilder.build());
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        results = tripDescriptorValidator.validate(MIN_POSIX_TIME, bullRunnerGtfs, bullRunnerGtfsMetadata, feedMessageBuilder.build(), null);
+        TestUtils.assertResults(ValidationRules.E032, results, 0);
+
+        clearAndInitRequiredFeedFields();
+    }
+
+    /**
+     * E033 - Alert informed_entity does not have any specifiers
+     */
+    @Test
+    public void testE033() {
+        TripDescriptorValidator tripDescriptorValidator = new TripDescriptorValidator();
+
+        GtfsRealtime.EntitySelector.Builder entitySelectorBuilder = GtfsRealtime.EntitySelector.newBuilder();
+
+        // Add an informed_entity without any specifiers - 1 error
+        alertBuilder.addInformedEntity(entitySelectorBuilder.build());
+        feedEntityBuilder.setAlert(alertBuilder.build());
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        results = tripDescriptorValidator.validate(MIN_POSIX_TIME, bullRunnerGtfs, bullRunnerGtfsMetadata, feedMessageBuilder.build(), null);
+        TestUtils.assertResults(ValidationRules.E033, results, 1);
+
+        // Set stop_id as specifier - 0 errors
+        entitySelectorBuilder.clear();
+        entitySelectorBuilder.setStopId("1234");
+        alertBuilder.clearInformedEntity();
+        alertBuilder.addInformedEntity(entitySelectorBuilder.build());
+        feedEntityBuilder.setAlert(alertBuilder.build());
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        results = tripDescriptorValidator.validate(MIN_POSIX_TIME, bullRunnerGtfs, bullRunnerGtfsMetadata, feedMessageBuilder.build(), null);
+        TestUtils.assertResults(ValidationRules.E033, results, 0);
+
+        // Set informed_entity.route_id as specifier - 0 errors
+        entitySelectorBuilder.clear();
+        entitySelectorBuilder.setRouteId("A");
+        alertBuilder.clearInformedEntity();
+        alertBuilder.addInformedEntity(entitySelectorBuilder.build());
+        feedEntityBuilder.setAlert(alertBuilder.build());
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        results = tripDescriptorValidator.validate(MIN_POSIX_TIME, bullRunnerGtfs, bullRunnerGtfsMetadata, feedMessageBuilder.build(), null);
+        TestUtils.assertResults(ValidationRules.E033, results, 0);
+
+        // Set agency_id as specifier - 0 errors
+        entitySelectorBuilder.clear();
+        entitySelectorBuilder.setAgencyId("1");
+        alertBuilder.clearInformedEntity();
+        alertBuilder.addInformedEntity(entitySelectorBuilder.build());
+        feedEntityBuilder.setAlert(alertBuilder.build());
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        results = tripDescriptorValidator.validate(MIN_POSIX_TIME, bullRunnerGtfs, bullRunnerGtfsMetadata, feedMessageBuilder.build(), null);
+        TestUtils.assertResults(ValidationRules.E033, results, 0);
+
+        // Set route_type as specifier - 0 errors
+        entitySelectorBuilder.clear();
+        entitySelectorBuilder.setRouteType(0);
+        alertBuilder.clearInformedEntity();
+        alertBuilder.addInformedEntity(entitySelectorBuilder.build());
+        feedEntityBuilder.setAlert(alertBuilder.build());
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        results = tripDescriptorValidator.validate(MIN_POSIX_TIME, bullRunnerGtfs, bullRunnerGtfsMetadata, feedMessageBuilder.build(), null);
+        TestUtils.assertResults(ValidationRules.E033, results, 0);
+
+        // Set trip_id as specifier - 0 errors
+        entitySelectorBuilder.clear();
+        entitySelectorBuilder.setTrip(GtfsRealtime.TripDescriptor.newBuilder().setTripId("1").build());
+        alertBuilder.clearInformedEntity();
+        alertBuilder.addInformedEntity(entitySelectorBuilder.build());
+        feedEntityBuilder.setAlert(alertBuilder.build());
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        results = tripDescriptorValidator.validate(MIN_POSIX_TIME, bullRunnerGtfs, bullRunnerGtfsMetadata, feedMessageBuilder.build(), null);
+        TestUtils.assertResults(ValidationRules.E033, results, 0);
+
+        // Set informed_entity.trip.route_id as specifier - 0 errors
+        entitySelectorBuilder.clear();
+        entitySelectorBuilder.setTrip(GtfsRealtime.TripDescriptor.newBuilder().setRouteId("A").build());
+        alertBuilder.clearInformedEntity();
+        alertBuilder.addInformedEntity(entitySelectorBuilder.build());
+        feedEntityBuilder.setAlert(alertBuilder.build());
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        results = tripDescriptorValidator.validate(MIN_POSIX_TIME, bullRunnerGtfs, bullRunnerGtfsMetadata, feedMessageBuilder.build(), null);
+        TestUtils.assertResults(ValidationRules.E033, results, 0);
+
+        // Clear all entity selectors again and don't set any - 1 error
+        entitySelectorBuilder.clear();
+        alertBuilder.clearInformedEntity();
+        alertBuilder.addInformedEntity(entitySelectorBuilder.build());
+        feedEntityBuilder.setAlert(alertBuilder.build());
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        results = tripDescriptorValidator.validate(MIN_POSIX_TIME, bullRunnerGtfs, bullRunnerGtfsMetadata, feedMessageBuilder.build(), null);
+        TestUtils.assertResults(ValidationRules.E033, results, 1);
+
+        clearAndInitRequiredFeedFields();
+    }
 }


### PR DESCRIPTION
~~**Please do not merge**~~

~~WIP to address https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/201 and https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/206 via new rules E030 and E031.~~

Fixes #201, #206, #209 with new rules:
* E030 - GTFS-rt alert `trip_id` does not belong to GTFS-rt alert `route_id` in GTFS `trips.txt`
* E031 - Alert `informed_entity.route_id` does not match `informed_entity.trip.route_id`
* E032 - Alert does not have an `informed_entity`
* E033 - Alert `informed_entity` does not have any specifiers
