### PR TITLE
Fix #137 - Hyperlink 'Last iteration' in Summary UI to iteration details page

### DIFF
--- a/src/main/resources/webroot/monitoring.html
+++ b/src/main/resources/webroot/monitoring.html
@@ -191,7 +191,7 @@
         <td>{{title}}</td>
 
         <td>{{severity}}</td>
-        <td>{{lastRowId}}</td>
+        <td><a href="iteration.html?iteration={{lastIterationId}}&sessionIteration={{lastRowId}}" target="_blank">{{lastRowId}}</a></td>
         <td title="Time zone: {{timeZone}}">{{formattedTimestamp}} ({{lastFeedTime}})</td>
 
         <td>{{count}}</td>


### PR DESCRIPTION

**Summary:**

Fixes #137. 

**Expected behavior:** 

`Last iteration` in Summary UI is hyperlinked to iteration details page. Now when we click on `Last iteration`, it should open related iteration details page.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "Fix #issue - short description of fix and changes"
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
