### PR TITLE
Fix#196 - Elapsed time for each iteration doesn't seem right

### DIFF
--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/util/GtfsUtils.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/util/GtfsUtils.java
@@ -72,8 +72,9 @@ public class GtfsUtils {
         long durationNanos = System.nanoTime() - startTimeNanos;
         long durationMillis = TimeUnit.NANOSECONDS.toMillis(durationNanos);
         long durationSeconds = TimeUnit.NANOSECONDS.toSeconds(durationNanos);
-
-        log.info(prefix + durationSeconds + "." + durationMillis + " seconds");
+        double elapsedTime = (double)durationSeconds+(double)durationMillis/1000.0;
+        elapsedTime = Math.round(elapsedTime*1000.0)/1000.0;
+        log.info(prefix + elapsedTime + " seconds");
     }
 
     /**


### PR DESCRIPTION
**Summary:**

Elapsed time for each iteration doesn't seem right. The reason behind this was logging of time elapsed was in improper format. Milliseconds were displayed right next to the decimal but they have been corrected now to display after two decimal places.

**Expected behavior:** 

![image](https://user-images.githubusercontent.com/28587713/27411074-8840e454-56b9-11e7-8144-bda37a55b157.png)



Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "Fix #issue - short description of fix and changes"
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
