### PR TITLE
Fix #214 - Properly separate data across simultaneous feeds

### DIFF
--- a/src/main/resources/webroot/custom-js/monitoring.js
+++ b/src/main/resources/webroot/custom-js/monitoring.js
@@ -50,6 +50,7 @@ for (var gtfsRtFeed in gtfsRtFeeds) {
             type: 'PUT',
             success: function (data) {
                 initializeInterface(data["gtfsRtFeedModel"]);
+                sessionStorage.setItem("sessionStartTime", data["sessionStartTime"]);
                 refresh(data["gtfsRtFeedModel"]["gtfsRtId"]);
 
                 // SessionId's for each of the GTFS-rt-feed. On 'stop' monitoring feeds, 'Session' table 'sessionEndTime' is updated using these sessionId's.
@@ -78,7 +79,8 @@ function loadGtfsErrorCount(gtfsFeedId) {
 function refresh(id) {
 
     $.get(server + "/api/gtfs-rt-feed/monitor-data/" + id +
-            "?summaryCurPage=" + paginationSummary[id]["currentPage"] +
+            "?startTime=" + sessionStorage.getItem("sessionStartTime") +
+            "&summaryCurPage=" + paginationSummary[id]["currentPage"] +
             "&summaryRowsPerPage=" + paginationSummary[id]["rowsPerPage"] +
             "&toggledData=" + hideErrors[id] +
             "&logCurPage=" + paginationLog[id]["currentPage"] +


### PR DESCRIPTION
**Summary:**

Towards multiple clients with simultaneous feeds monitoring. ~~Fixes #215.~~ Fixes #214.

**Expected behavior:** 

 Multiple clients are monitored without mixing the errors/warnings.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "Fix #issue - short description of fix and changes"
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
