### PR TITLE
Fix #198 - Allow hyperlinking of text in occurrence summary

### DIFF
--- a/src/main/resources/webroot/iteration.html
+++ b/src/main/resources/webroot/iteration.html
@@ -116,7 +116,7 @@
         <tr>
             <td class="iterations-td">{{rowId}}</td>
             <td style="display:none;" data-tableexport-display="always">{{errorId}}</td>
-            <td class="iterations-td">{{occurrencePrefix}} {{occurrenceSuffix}}</td>
+            <td class="iterations-td">{{{occurrencePrefix}}} {{occurrenceSuffix}}</td>
         </tr>
         {{/each}}
     </script>


### PR DESCRIPTION
**Summary:**

Rendering HTML elements in OccurrenceModel.prefix string. Fixes #198. 

**Expected behavior:** 

If any HTML element is added to the OccurrenceModel.prefix string, it is treated as HTML element instead of plaint text. 

Suppose, try adding `<a href='http://geojson.io/#map=15/27.995876/-82.44294'>(27.995876,-82.44294)</a>` as part of any error/warnings **OccurrenceModel.prefix** description, it will be treated as a hyperlink in error/warning summary in iteraiton.html page.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "Fix #issue - short description of fix and changes"
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
