### PR TITLE
WIP - Fix #168 - Add unit test for date generating error

### DIFF
--- a/src/test/java/edu/usf/cutr/gtfsrtvalidator/test/UtilTest.java
+++ b/src/test/java/edu/usf/cutr/gtfsrtvalidator/test/UtilTest.java
@@ -154,6 +154,9 @@ public class UtilTest {
         validDate = "20170427";
         assertEquals(true, TimestampUtils.isValidDateFormat(validDate));
 
+        validDate = "20170706";
+        assertEquals(true, TimestampUtils.isValidDateFormat(validDate));
+
         /**
          * Bad dates
          */


### PR DESCRIPTION
See https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/168#issuecomment-313437398

Strangely, when I add a unit test for the exact date `20170706` that incorrectly generated the error for invalid date format, it passes the unit test.  We need to dig in deeper to figure out why it's incorrectly generating the error.