### PR TITLE
Fix #215 - Support multiple clients with simultaneous feed monitoring

### DIFF
--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/GtfsRtFeedModel.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/GtfsRtFeedModel.java
@@ -31,8 +31,6 @@ public class GtfsRtFeedModel implements Serializable {
     @ManyToOne
     @JoinColumn(name = "gtfsFeedID")
     private GtfsFeedModel gtfsFeedModel;
-    @Column(name="startTime")
-    private long startTime;
     @Id
     @GeneratedValue(strategy=GenerationType.IDENTITY)
     @Column(name="rtFeedID")
@@ -56,14 +54,6 @@ public class GtfsRtFeedModel implements Serializable {
         this.gtfsFeedModel = gtfsFeedModel;
     }
 
-    public long getStartTime() {
-        return startTime;
-    }
-
-    public void setStartTime(long startTime) {
-        this.startTime = startTime;
-    }
-
     public int getGtfsRtId() {
         return gtfsRtId;
     }
@@ -77,7 +67,6 @@ public class GtfsRtFeedModel implements Serializable {
         return "GtfsRtFeedModel{" +
                 "gtfsUrl='" + gtfsUrl + '\'' +
                 ", gtfsId=" + gtfsFeedModel.getFeedId() +
-                ", startTime=" + startTime +
                 ", gtfsRtId=" + gtfsRtId +
                 '}';
     }

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/GtfsRtFeedModel.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/GtfsRtFeedModel.java
@@ -55,15 +55,15 @@ public class GtfsRtFeedModel implements Serializable {
     public void setGtfsFeedModel(GtfsFeedModel gtfsFeedModel) {
         this.gtfsFeedModel = gtfsFeedModel;
     }
-    
+
     public long getStartTime() {
         return startTime;
     }
-    
+
     public void setStartTime(long startTime) {
         this.startTime = startTime;
     }
-    
+
     public int getGtfsRtId() {
         return gtfsRtId;
     }

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/GtfsRtFeedModel.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/GtfsRtFeedModel.java
@@ -77,7 +77,7 @@ public class GtfsRtFeedModel implements Serializable {
         return "GtfsRtFeedModel{" +
                 "gtfsUrl='" + gtfsUrl + '\'' +
                 ", gtfsId=" + gtfsFeedModel.getFeedId() +
-                ", startTime=" + startTime +            
+                ", startTime=" + startTime +
                 ", gtfsRtId=" + gtfsRtId +
                 '}';
     }

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/GtfsRtFeedModel.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/GtfsRtFeedModel.java
@@ -31,6 +31,8 @@ public class GtfsRtFeedModel implements Serializable {
     @ManyToOne
     @JoinColumn(name = "gtfsFeedID")
     private GtfsFeedModel gtfsFeedModel;
+    @Column(name="startTime")
+    private long startTime;
     @Id
     @GeneratedValue(strategy=GenerationType.IDENTITY)
     @Column(name="rtFeedID")
@@ -53,7 +55,15 @@ public class GtfsRtFeedModel implements Serializable {
     public void setGtfsFeedModel(GtfsFeedModel gtfsFeedModel) {
         this.gtfsFeedModel = gtfsFeedModel;
     }
-
+    
+    public long getStartTime() {
+        return startTime;
+    }
+    
+    public void setStartTime(long startTime) {
+        this.startTime = startTime;
+    }
+    
     public int getGtfsRtId() {
         return gtfsRtId;
     }

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/GtfsRtFeedModel.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/GtfsRtFeedModel.java
@@ -77,6 +77,7 @@ public class GtfsRtFeedModel implements Serializable {
         return "GtfsRtFeedModel{" +
                 "gtfsUrl='" + gtfsUrl + '\'' +
                 ", gtfsId=" + gtfsFeedModel.getFeedId() +
+                ", startTime=" + startTime +            
                 ", gtfsRtId=" + gtfsRtId +
                 '}';
     }

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/SessionModel.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/SessionModel.java
@@ -50,6 +50,9 @@ public class SessionModel implements Serializable {
     @Column(name = "warningCount")
     private int warningCount = 0;
 
+    @Column(name = "updateInterval")
+    private Integer updateInterval = 0;
+
     // To retrieve records sequentially starting from 1
     @Transient
     private int rowId;
@@ -145,6 +148,10 @@ public class SessionModel implements Serializable {
     public void setWarningCount(int warningCount) {
         this.warningCount = warningCount;
     }
+
+    public Integer getUpdateInterval() { return updateInterval; }
+
+    public void setUpdateInterval(Integer updateInterval) { this.updateInterval = updateInterval; }
 
     public int getRowId() {
         return rowId;

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsRtFeed.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsRtFeed.java
@@ -69,8 +69,6 @@ public class GtfsRtFeed {
     @Produces(MediaType.APPLICATION_JSON)
     public Response postGtfsRtFeed(GtfsRtFeedModel feedInfo) {
         //feedInfo.setGtfsId(1);
-        feedInfo.setStartTime(System.currentTimeMillis());
-
         //Validate URL for GTFS feed and the GTFS ID.
         if (feedInfo.getGtfsUrl() == null) {
             return generateError("GTFS-RT URL is required");

--- a/src/main/resources/webroot/custom-js/monitoring.js
+++ b/src/main/resources/webroot/custom-js/monitoring.js
@@ -260,10 +260,12 @@ function stopMonitor() {
         if (sessionIds.hasOwnProperty(sessionId)) {
             $.ajax({
                 url: server + "/api/gtfs-rt-feed/" + sessionIds[sessionId] + "/closeSession",
+                async: false,
                 type: 'PUT'
             });
         }
     }
+    window.location = server;
 }
 
 function showOrHideError(gtfsRtId, errorId) {

--- a/src/main/resources/webroot/monitoring.html
+++ b/src/main/resources/webroot/monitoring.html
@@ -204,7 +204,7 @@
     {{#each this}}
     <tr>
         <td><a href="iteration.html?iteration={{iterationId}}&sessionIteration={{rowId}}" target="_blank">{{rowId}}</a></td>
-        <td>{{id}}</td>
+        <td><a href="https://github.com/CUTR-at-USF/gtfs-realtime-validator/blob/master/RULES.md#{{id}}" target="_blank">{{id}}</a></td>
         <td>{{title}}</td>
 
         <td>{{severity}}</td>

--- a/src/test/resources/testSQLScript.sql
+++ b/src/test/resources/testSQLScript.sql
@@ -6,9 +6,9 @@ INSERT INTO GtfsFeed -- Columns (feedId, agency, fileCheckSum, errorCount, fileL
     WHERE NOT EXISTS (SELECT * FROM GtfsFeed WHERE feedId = -1);
 
 -- Insert records into GtfsRtFeed table
-INSERT INTO GtfsRtFeed -- Columns (rtFeedId, rtFeedUrl, startTime, gtfsFeedId)
+INSERT INTO GtfsRtFeed -- Columns (rtFeedId, rtFeedUrl, gtfsFeedId)
     -- We ensures that record is not inserted if already exists, to avoid primary key constraint violation
-    SELECT * FROM (VALUES( -1, 'dummy', 1, -1))
+    SELECT * FROM (VALUES( -1, 'dummy', -1))
     WHERE NOT EXISTS (SELECT * FROM GtfsRtFeed WHERE rtFeedId = -1);
 
 -- Insert records into GtfsRtFeedIteration


### PR DESCRIPTION
**Summary:**

Fixed #204, one client wants to monitor the feed more often than another, user enters more than one GTFS-realtime feed 

**Expected behavior:** 

The tool should properly separate sessions and feed validation data. There should be a single thread fetching the GTFS-rt data and generating validation results for each feed being monitored, with each client having a view of that feed data based on their session start (and end) times.

- [X] Run the unit tests with `mvn test` to make sure you didn't break anything
- [X] Format the title like "Fix #issue - short description of fix and changes"
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)
