### PR TITLE
Fix #215 - Support multiple clients with simultaneous feed monitoring

### DIFF
--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/helper/ServiceScheduler.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/helper/ServiceScheduler.java
@@ -1,0 +1,33 @@
+package edu.usf.cutr.gtfsrtvalidator.helper;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+public class ServiceScheduler {
+    ScheduledExecutorService scheduler;
+    Integer updateInterval;
+    Integer parallelClientCount;
+
+    public Integer getUpdateInterval() {
+        return updateInterval;
+    }
+
+    public void setUpdateInterval(Integer updateInterval) {
+        this.updateInterval = updateInterval;
+    }
+
+    public Integer getParallelClientCount() {
+        return parallelClientCount;
+    }
+
+    public void setParallelClientCount(Integer parallelClientCount) {
+        this.parallelClientCount = parallelClientCount;
+    }
+
+    public ScheduledExecutorService getScheduler() {
+        return scheduler;
+    }
+
+    public void setScheduler(ScheduledExecutorService scheduler) {
+        this.scheduler = scheduler;
+    }
+}

--- a/src/main/resources/webroot/custom-js/monitoring.js
+++ b/src/main/resources/webroot/custom-js/monitoring.js
@@ -41,6 +41,7 @@ var sessionIds = [];
 
 var toggleDataOn = '<input type="checkbox" checked data-toggle="toggle" data-onstyle="success"/>';
 var toggleDataOff = '<input type="checkbox" data-toggle="toggle" data-onstyle="success"/>';
+var sessionClosed = 0;
 
 //PUT request to start monitoring of the given gtfsRtFeed ID /api/gtfs-rt-feed/{id}/monitor
 for (var gtfsRtFeed in gtfsRtFeeds) {
@@ -260,10 +261,13 @@ function stopMonitor() {
         if (sessionIds.hasOwnProperty(sessionId)) {
             $.ajax({
                 url: server + "/api/gtfs-rt-feed/" + sessionIds[sessionId] + "/closeSession",
+                async: false,
                 type: 'PUT'
             });
         }
     }
+    sessionClosed = 1;
+    window.location = server;
 }
 
 function showOrHideError(gtfsRtId, errorId) {
@@ -322,5 +326,7 @@ $(document).ready(function(){
 });
 
 window.onbeforeunload = function(){
-  stopMonitor();
+    if (sessionClosed == 0) {
+        stopMonitor();
+    }
 }


### PR DESCRIPTION
**Summary:**

Multiple clients with simultaneous feed monitoring is supported now

**Expected behavior:** 

The tool should properly separate sessions and feed validation data. There should be a single thread fetching the GTFS-rt data and generating validation results for each feed being monitored, with each client having a view of that feed data based on their session start (and end) times.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Run the unit tests with `mvn test` to make sure you didn't break anything
- [X] Format the title like "Fix #issue - short description of fix and changes"
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)
