### PR TITLE
Fix #196 - Elapsed time for each iteration doesn't seem right

### DIFF
--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/util/GtfsUtils.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/util/GtfsUtils.java
@@ -232,4 +232,19 @@ public class GtfsUtils {
             return "stop_id " + stopTimeUpdate.getStopId();
         }
     }
+
+    /**
+     * Returns the elapsed time by taking start-time as input
+     *
+     * @param startTimeNanos the startTime in nanoseconds
+     * @return the elapsedTime as the difference between System.nanoTime() and startTimeNanos".
+     */
+    public static double getElapsedTime(long startTimeNanos){
+        long durationNanos = System.nanoTime() - startTimeNanos;
+        long durationMillis = TimeUnit.NANOSECONDS.toMillis(durationNanos);
+        long durationSeconds = TimeUnit.NANOSECONDS.toSeconds(durationNanos);
+        double elapsedTime = (double)durationSeconds+(double)durationMillis/1000.0;
+        elapsedTime = Math.round(elapsedTime*1000.0)/1000.0;
+        return elapsedTime;
+    }
 }


### PR DESCRIPTION
**Summary:**

Used thread synchronization when logging the duration.

**Expected behavior:** 

The sum of benchmark times for all rules should be the same or less than the total time it took to process the feed.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Run the unit tests with `mvn test` to make sure you didn't break anything
- [X] Format the title like "Fix #issue - short description of fix and changes"
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)
