### PR TITLE
Fix #242 - Turn off sql statement

### DIFF
--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -4,7 +4,7 @@
   <session-factory>
     <property name="hibernate.dialect">org.hibernate.dialect.HSQLDialect</property>
     <property name="hibernate.connection.driver_class">org.hsqldb.jdbcDriver</property>
-    <property name="hibernate.connection.url">jdbc:hsqldb:file:gtfsrthsql</property>
+    <property name="hibernate.connection.url">jdbc:hsqldb:file:gtfsrthsql;hsqldb.log_data=false</property>
     <property name="hibernate.c3p0.min_size">1</property>
     <property name="hibernate.c3p0.max_size">1</property>
     <property name="hibernate.c3p0.timeout">1800</property>


### PR DESCRIPTION
**Summary:**

Pass hsqldb property log_data as false to hibernate configuration.

**Expected behavior:** 

Logging is disabled and SQL statement logging in script file has been stopped.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Run the unit tests with `mvn test` to make sure you didn't break anything
- [X] Format the title like "Fix #issue - short description of fix and changes"
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)
