### PR TITLE
Fix #267 - Eliminate extra inputstream when reading protobuf

### DIFF
--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/background/BackgroundTask.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/background/BackgroundTask.java
@@ -129,9 +129,7 @@ public class BackgroundTask implements Runnable {
                     isUniqueFeed = false;
                 }
 
-                InputStream is = new ByteArrayInputStream(gtfsRtProtobuf);
-                currentFeedMessage = GtfsRealtime.FeedMessage.parseFrom(is);
-
+                currentFeedMessage = GtfsRealtime.FeedMessage.parseFrom(gtfsRtProtobuf);
                 long feedTimestamp = TimeUnit.SECONDS.toMillis(currentFeedMessage.getHeader().getTimestamp());
 
                 // Create new feedIteration object and save the iteration to the database


### PR DESCRIPTION
**Summary:**

The extra allocation of an `InputStream` is removed when reading the GTFS-rt protocol buffer message.

**Expected behavior:** 

Behavior should be the exact same as the master branch (i.e., reading and storing GTFS-rt protobuf), just without an extra allocation of an `InputStream`.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Run the unit tests with `mvn test` to make sure you didn't break anything
- [X] Format the title like "Fix #issue - short description of fix and changes"
- [X] Linked all relevant issues

@Suryakandukoori Could you please review and merge if everything looks good?