### PR TITLE
Fix #262 - Implement errors for GTFS-rt v2.0

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -49,6 +49,8 @@ Rules are declared in the [`ValidationRules` class](https://github.com/CUTR-at-U
 | [E045](#E045) | GTFS-rt `stop_time_update` `stop_sequence` and `stop_id` do not match GTFS
 | [E046](#E046) | GTFS-rt `stop_time_update` without `time` doesn't have arrival/departure time in GTFS
 | [E047](#E047) | `VehiclePosition` and `TripUpdate` ID pairing mismatch
+| [E048](#E048) | `header` `timestamp` not populated (GTFS-rt v2.0 and higher)
+| [E049](#E049) | `header` `incrementality` not populated (GTFS-rt v2.0 and higher)
 
 ### Table of Warnings
 
@@ -521,7 +523,7 @@ Sequential GTFS-rt trip `stop_time_updates` shouldn't have the same `stop_id` - 
 
 ### E038 - Invalid `header.gtfs_realtime_version`
 
-`header.gtfs_realtime_version` should be a valid value.  Currently, the only valid values are `1.0` and `v2.0`.
+`header.gtfs_realtime_version` is required and must be a valid value.  Currently, the only valid values are `1.0` and `v2.0`.
 
 #### References:
 * [`header.gtfs_realtime_version`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-feedheader)
@@ -645,6 +647,24 @@ Note that this is different from W003, which simply checks to see if an ID that 
 #### References:
 * [`vehicle.id`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-vehicledescriptor)
 * [`trip.trip_id`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-tripdescriptor)
+
+<a name="E048"/>
+
+### E048 - `header` `timestamp` not populated (GTFS-rt v2.0 and higher)
+
+`timestamp` must be populated in `FeedHeader` for `gtfs_realtime_version` v2.0 and higher.
+
+#### References:
+* [`header.timestamp`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-feedheader)
+
+<a name="E049"/>
+
+### E049 - `header` `incrementality` not populated (GTFS-rt v2.0 and higher)
+
+`incrementality` must be populated in `FeedHeader` for `gtfs_realtime_version` v2.0 and higher.
+
+#### References:
+* [`header.incrementality`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-feedheader)
 
 # Warnings
 

--- a/RULES.md
+++ b/RULES.md
@@ -521,7 +521,7 @@ Sequential GTFS-rt trip `stop_time_updates` shouldn't have the same `stop_id` - 
 
 ### E038 - Invalid `header.gtfs_realtime_version`
 
-`header.gtfs_realtime_version` should be a valid value.  Currently, the only valid value is `1.0`.
+`header.gtfs_realtime_version` should be a valid value.  Currently, the only valid values are `1.0` and `v2.0`.
 
 #### References:
 * [`header.gtfs_realtime_version`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-feedheader)

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/util/GtfsUtils.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/util/GtfsUtils.java
@@ -28,6 +28,33 @@ import static org.locationtech.spatial4j.context.SpatialContext.GEO;
  */
 public class GtfsUtils {
 
+    public static final String GTFS_RT_V1 = "1.0";
+    public static final String GTFS_RT_V2 = "2.0";
+
+    /**
+     * Returns true if the version for the provided GTFS-rt header is valid, false if it is not
+     *
+     * @param feedHeader the feed header to check the version for
+     * @return true if the version for the provided GTFS-rt header is valid, false if it is not
+     */
+    public static boolean isValidVersion(GtfsRealtime.FeedHeader feedHeader) {
+        return !feedHeader.hasGtfsRealtimeVersion() || feedHeader.getGtfsRealtimeVersion().equals(GTFS_RT_V1) || feedHeader.getGtfsRealtimeVersion().equals(GTFS_RT_V2);
+    }
+
+    /**
+     * Returns true if the version for the provided GTFS-rt header is v2 or higher, false if the version is v1 or unrecognized
+     *
+     * @param feedHeader the feed header to check the version for
+     * @return true if the version for the provided GTFS-rt header is v2 or higher, false if the version is v1 or unrecognized
+     */
+    public static boolean isV2orHigher(GtfsRealtime.FeedHeader feedHeader) {
+        float version = Float.parseFloat(feedHeader.getGtfsRealtimeVersion());
+        if (version >= 2.0f) {
+            return true;
+        }
+        return false;
+    }
+
     /**
      * Returns true if this tripDescriptor has a schedule_relationship of ADDED, false if it does not
      *

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/ValidationRules.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/ValidationRules.java
@@ -240,4 +240,12 @@ public class ValidationRules {
     public static final ValidationRule E047 = new ValidationRule("E047", "ERROR", "VehiclePosition and TripUpdate ID pairing mismatch",
             "If separate `VehiclePositions` and `TripUpdates` feeds are provided, `VehicleDescriptor` or `TripDescriptor` ID value pairing should match between the two feeds.",
             "- ID pairing between feeds should match");
+
+    public static final ValidationRule E048 = new ValidationRule("E048", "ERROR", "header timestamp not populated",
+            "Header timestamp must be populated for gtfs_realtime_version v2.0 and higher",
+            "Header does not have a timestamp and gtfs_realtime_version is v2.0 or higher");
+
+    public static final ValidationRule E049 = new ValidationRule("E049", "ERROR", "header incrementality not populated",
+            "Header incrementality must be populated for gtfs_realtime_version v2.0 and higher",
+            "Header does not have incrementality and gtfs_realtime_version is v2.0 or higher");
 }

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/rules/HeaderValidator.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/rules/HeaderValidator.java
@@ -46,7 +46,7 @@ public class HeaderValidator implements FeedEntityValidator {
         List<OccurrenceModel> errorListE039 = new ArrayList<>();
 
         String version = feedMessage.getHeader().getGtfsRealtimeVersion();
-        if (!version.equals("1.0")) {
+        if (!(version.equals("1.0") || version.equals("2.0"))) {
             // E038 - Invalid header.gtfs_realtime_version
             RuleUtils.addOccurrence(E038, "header.gtfs_realtime_version of " + version, errorListE038, _log);
         }

--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/rules/HeaderValidator.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/validation/rules/HeaderValidator.java
@@ -21,6 +21,7 @@ import edu.usf.cutr.gtfsrtvalidator.api.model.MessageLogModel;
 import edu.usf.cutr.gtfsrtvalidator.api.model.OccurrenceModel;
 import edu.usf.cutr.gtfsrtvalidator.background.GtfsMetadata;
 import edu.usf.cutr.gtfsrtvalidator.helper.ErrorListHelperModel;
+import edu.usf.cutr.gtfsrtvalidator.util.GtfsUtils;
 import edu.usf.cutr.gtfsrtvalidator.util.RuleUtils;
 import edu.usf.cutr.gtfsrtvalidator.validation.interfaces.FeedEntityValidator;
 import org.onebusaway.gtfs.impl.GtfsDaoImpl;
@@ -29,12 +30,12 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 
-import static edu.usf.cutr.gtfsrtvalidator.validation.ValidationRules.E038;
-import static edu.usf.cutr.gtfsrtvalidator.validation.ValidationRules.E039;
+import static edu.usf.cutr.gtfsrtvalidator.validation.ValidationRules.*;
 
 /**
  * E038 - Invalid header.gtfs_realtime_version
  * E039 - FULL_DATASET feeds should not include entity.is_deleted
+ * E049 - header incrementality not populated
  */
 public class HeaderValidator implements FeedEntityValidator {
 
@@ -44,11 +45,20 @@ public class HeaderValidator implements FeedEntityValidator {
     public List<ErrorListHelperModel> validate(long currentTimeMillis, GtfsDaoImpl gtfsData, GtfsMetadata gtfsMetadata, GtfsRealtime.FeedMessage feedMessage, GtfsRealtime.FeedMessage previousFeedMessage, GtfsRealtime.FeedMessage combinedFeedMessage) {
         List<OccurrenceModel> errorListE038 = new ArrayList<>();
         List<OccurrenceModel> errorListE039 = new ArrayList<>();
+        List<OccurrenceModel> errorListE049 = new ArrayList<>();
 
-        String version = feedMessage.getHeader().getGtfsRealtimeVersion();
-        if (!(version.equals("1.0") || version.equals("2.0"))) {
+        if (!GtfsUtils.isValidVersion(feedMessage.getHeader())) {
             // E038 - Invalid header.gtfs_realtime_version
-            RuleUtils.addOccurrence(E038, "header.gtfs_realtime_version of " + version, errorListE038, _log);
+            RuleUtils.addOccurrence(E038, "header.gtfs_realtime_version of " + feedMessage.getHeader().getGtfsRealtimeVersion(), errorListE038, _log);
+        }
+
+        try {
+            if (GtfsUtils.isV2orHigher(feedMessage.getHeader()) && !feedMessage.getHeader().hasIncrementality()) {
+                // E049 - header incrementality not populated
+                RuleUtils.addOccurrence(E049, "", errorListE049, _log);
+            }
+        } catch (Exception e) {
+            _log.error("Error checking header version for E049: " + e);
         }
 
         if (feedMessage.getHeader().getIncrementality().equals(GtfsRealtime.FeedHeader.Incrementality.FULL_DATASET)) {
@@ -66,6 +76,9 @@ public class HeaderValidator implements FeedEntityValidator {
         }
         if (!errorListE039.isEmpty()) {
             errors.add(new ErrorListHelperModel(new MessageLogModel(E039), errorListE039));
+        }
+        if (!errorListE049.isEmpty()) {
+            errors.add(new ErrorListHelperModel(new MessageLogModel(E049), errorListE049));
         }
         return errors;
     }

--- a/src/test/java/edu/usf/cutr/gtfsrtvalidator/test/UtilTest.java
+++ b/src/test/java/edu/usf/cutr/gtfsrtvalidator/test/UtilTest.java
@@ -322,6 +322,20 @@ public class UtilTest {
     }
 
     @Test
+    public void testIsV2orHigher() {
+        GtfsRealtime.FeedHeader.Builder builder = GtfsRealtime.FeedHeader.newBuilder();
+
+        builder.setGtfsRealtimeVersion("1.0");
+        assertFalse(GtfsUtils.isV2orHigher(builder.build()));
+
+        builder.setGtfsRealtimeVersion("2.0");
+        assertTrue(GtfsUtils.isV2orHigher(builder.build()));
+
+        builder.setGtfsRealtimeVersion("3.0");
+        assertTrue(GtfsUtils.isV2orHigher(builder.build()));
+    }
+
+    @Test
     public void testGetVehicleAndTripId() {
         String text;
 

--- a/src/test/java/edu/usf/cutr/gtfsrtvalidator/test/rules/HeaderValidatorTest.java
+++ b/src/test/java/edu/usf/cutr/gtfsrtvalidator/test/rules/HeaderValidatorTest.java
@@ -56,12 +56,12 @@ public class HeaderValidatorTest extends FeedMessageTest {
         expected.clear();
         TestUtils.assertResults(expected, results);
 
-        // Bad version - one error
+        // Valid version - no errors
         headerBuilder.setGtfsRealtimeVersion("2.0");
         feedMessageBuilder.setHeader(headerBuilder.build());
 
         results = headerValidator.validate(MIN_POSIX_TIME, gtfsData, gtfsDataMetadata, feedMessageBuilder.build(), null, null);
-        expected.put(E038, 1);
+        expected.clear();
         TestUtils.assertResults(expected, results);
 
         // Bad version - one error

--- a/src/test/java/edu/usf/cutr/gtfsrtvalidator/test/rules/HeaderValidatorTest.java
+++ b/src/test/java/edu/usf/cutr/gtfsrtvalidator/test/rules/HeaderValidatorTest.java
@@ -27,8 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static edu.usf.cutr.gtfsrtvalidator.util.TimestampUtils.MIN_POSIX_TIME;
-import static edu.usf.cutr.gtfsrtvalidator.validation.ValidationRules.E038;
-import static edu.usf.cutr.gtfsrtvalidator.validation.ValidationRules.E039;
+import static edu.usf.cutr.gtfsrtvalidator.validation.ValidationRules.*;
 
 /**
  * Tests for rules implemented in HeaderValidator
@@ -56,12 +55,21 @@ public class HeaderValidatorTest extends FeedMessageTest {
         expected.clear();
         TestUtils.assertResults(expected, results);
 
-        // Valid version - no errors
+        // Valid version, and set incrementality to avoid E049 - no errors
         headerBuilder.setGtfsRealtimeVersion("2.0");
+        headerBuilder.setIncrementality(GtfsRealtime.FeedHeader.Incrementality.FULL_DATASET);
         feedMessageBuilder.setHeader(headerBuilder.build());
 
         results = headerValidator.validate(MIN_POSIX_TIME, gtfsData, gtfsDataMetadata, feedMessageBuilder.build(), null, null);
         expected.clear();
+        TestUtils.assertResults(expected, results);
+
+        // Bad version - 1 error
+        headerBuilder.setGtfsRealtimeVersion("3.0");
+        feedMessageBuilder.setHeader(headerBuilder.build());
+
+        results = headerValidator.validate(MIN_POSIX_TIME, gtfsData, gtfsDataMetadata, feedMessageBuilder.build(), null, null);
+        expected.put(E038, 1);
         TestUtils.assertResults(expected, results);
 
         // Bad version - one error
@@ -140,6 +148,44 @@ public class HeaderValidatorTest extends FeedMessageTest {
         feedMessageBuilder.setHeader(headerBuilder.build());
         feedEntityBuilder.setIsDeleted(true);
         feedMessageBuilder.addEntity(feedEntityBuilder.build());
+        results = headerValidator.validate(MIN_POSIX_TIME, gtfsData, gtfsDataMetadata, feedMessageBuilder.build(), null, null);
+        expected.clear();
+        TestUtils.assertResults(expected, results);
+
+        clearAndInitRequiredFeedFields();
+    }
+
+    /**
+     * E038 - Invalid header.gtfs_realtime_version
+     */
+    @Test
+    public void testE049() {
+        HeaderValidator headerValidator = new HeaderValidator();
+        Map<ValidationRule, Integer> expected = new HashMap<>();
+
+        GtfsRealtime.FeedHeader.Builder headerBuilder = GtfsRealtime.FeedHeader.newBuilder();
+
+        // GTFS-rt v1.0, and no incrementality - no errors
+        headerBuilder.setGtfsRealtimeVersion("1.0");
+        feedMessageBuilder.setHeader(headerBuilder.build());
+
+        results = headerValidator.validate(MIN_POSIX_TIME, gtfsData, gtfsDataMetadata, feedMessageBuilder.build(), null, null);
+        expected.clear();
+        TestUtils.assertResults(expected, results);
+
+        // GTFS-rt v2.0, and no incrementality - 1 error
+        headerBuilder.setGtfsRealtimeVersion("2.0");
+        feedMessageBuilder.setHeader(headerBuilder.build());
+
+        results = headerValidator.validate(MIN_POSIX_TIME, gtfsData, gtfsDataMetadata, feedMessageBuilder.build(), null, null);
+        expected.put(E049, 1);
+        TestUtils.assertResults(expected, results);
+
+        // GTFS-rt v2.0, and has incrementality - no errors
+        headerBuilder.setGtfsRealtimeVersion("2.0");
+        headerBuilder.setIncrementality(GtfsRealtime.FeedHeader.Incrementality.FULL_DATASET);
+        feedMessageBuilder.setHeader(headerBuilder.build());
+
         results = headerValidator.validate(MIN_POSIX_TIME, gtfsData, gtfsDataMetadata, feedMessageBuilder.build(), null, null);
         expected.clear();
         TestUtils.assertResults(expected, results);


### PR DESCRIPTION
~~**Please do not merge**~~

* Update `E038`  - Add v2.0 as a valid GTFS-rt version and update `E038` unit test
* New rule `E048` - header timestamp not populated (GTFS-rt v2.0 and higher), and unit test
* New rule `E049` - header incrementality not populated (GTFS-rt v2.0 and higher), and unit test