### PR TITLE
Fix #253 - NPE on first feed iteration when monitoring multiple feeds

### DIFF
--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/background/BackgroundTask.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/background/BackgroundTask.java
@@ -36,12 +36,10 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.MessageDigest;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.TimeZone;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static edu.usf.cutr.gtfsrtvalidator.util.TimestampUtils.getElapsedTime;
 import static edu.usf.cutr.gtfsrtvalidator.util.TimestampUtils.getElapsedTimeString;
@@ -178,6 +176,9 @@ public class BackgroundTask implements Runnable {
 
             GTFSDB.closeSession(session);
 
+            while (!mGtfsRtFeedMap.keySet().containsAll(gtfsRtFeedModelList.stream().map(GtfsRtFeedModel::getGtfsRtId).collect(Collectors.toSet()))) {
+                Thread.sleep(200);
+            }
             GtfsRealtime.FeedHeader header = null;
 
             if (gtfsRtFeedModelList.size() < 1) {


### PR DESCRIPTION
**Summary:**

When monitoring the MBTA VehiclePositions and TripUpdates feeds together, the first feed iteration generates a NullPointerException.

**Expected behavior:** 

Not generate an NPE.

- [X] Run the unit tests with `mvn test` to make sure you didn't break anything
- [X] Format the title like "Fix #issue - short description of fix and changes"
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)
