### PR TITLE
Fix #275 - Add link on Monitoring Feeds page to view most recent feed response

### DIFF
--- a/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/ViewFeedMessageModel.java
+++ b/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/model/ViewFeedMessageModel.java
@@ -27,11 +27,18 @@ import java.io.InputStream;
 
 @XmlRootElement
 @Entity
-@NamedNativeQuery(name = "feedMessageByIterationId",
-        query = "SELECT feedProtobuf AS feedMessage " +
-                "FROM GtfsRtFeedIteration " +
-                "WHERE IterationID = ? ",
-        resultClass = ViewFeedMessageModel.class)
+@NamedNativeQueries ({
+    @NamedNativeQuery (name = "feedMessageByIterationId",
+            query = "SELECT feedProtobuf AS feedMessage " +
+                    "FROM GtfsRtFeedIteration " +
+                    "WHERE IterationID = ? ",
+            resultClass = ViewFeedMessageModel.class),
+    @NamedNativeQuery (name = "feedMessageByGtfsRtId",
+            query = "SELECT feedProtobuf AS feedMessage " +
+                    "FROM GtfsRtFeedIteration " +
+                    "WHERE rtFeedId = ?  ORDER BY IterationTimestamp DESC",
+            resultClass = ViewFeedMessageModel.class)
+})
 public class ViewFeedMessageModel {
 
     @Id

--- a/src/main/resources/webroot/custom-js/iteration.js
+++ b/src/main/resources/webroot/custom-js/iteration.js
@@ -18,6 +18,7 @@
 // Get data from URL.
 var rowId = getUrlParameter("sessionIteration");
 var iterationId = getUrlParameter("iteration");
+var gtfsRtId = getUrlParameter("gtfsRtId");
 
 // These variables store data that is needed when showing more and less errors for each error/warning.
 var showMoreErrorList;
@@ -29,9 +30,12 @@ var allTablesData = '';
 
 var server = window.location.protocol + "//" + window.location.host;
 $(".feed-page-loader").show();
-$(".issues-page-loader").show();
-
-$.get(server + "/api/gtfs-rt-feed/" + iterationId + "/iterationDetails").done(function (data) {
+if(iterationId != -1) {
+    $(".issues-page-loader").show();
+} else {
+    $(".issues-page-loader").hide();
+}
+$.get(server + "/api/gtfs-rt-feed/" + iterationId + "/" + gtfsRtId + "/iterationDetails").done(function (data) {
     var timestamp = data["feedTimestamp"];
     var dateFormat = data["dateFormat"];
     var gtfsRtUrl = data["gtfsRtFeedModel"]["gtfsUrl"];
@@ -40,7 +44,7 @@ $.get(server + "/api/gtfs-rt-feed/" + iterationId + "/iterationDetails").done(fu
 });
 
 // Get the feedMessage from server for a particular 'iterationId' and display in plain text format to user.
-$.get(server + "/api/gtfs-rt-feed/" + iterationId + "/feedMessage").done(function (data) {
+$.get(server + "/api/gtfs-rt-feed/" + iterationId + "/" + gtfsRtId + "/feedMessage").done(function (data) {
     var jsonFeed = JSON.stringify(data, undefined, 2);
     document.getElementById("feedMessage").innerHTML = jsonFeed;
 
@@ -65,81 +69,82 @@ clipboard.on('error', function(e) {
     hideTooltip(btn);
 });
 
+if(iterationId != -1) {
 // Get the list of errors/warnings and list of their occurrences from server for a particular 'iterationId'.
-$.get(server + "/api/gtfs-rt-feed/" + iterationId + "/iterationErrors").done(function (data) {
+    $.get(server + "/api/gtfs-rt-feed/" + iterationId + "/iterationErrors").done(function (data) {
 
-    showMoreErrorList = data;
-    var errorCount = 0;
-    var warningCount = 0;
+        showMoreErrorList = data;
+        var errorCount = 0;
+        var warningCount = 0;
 
-    // Get the correct count of error occurrences to show in text '...and xx more'
-    for (errorListIndex in data) {
-        data[errorListIndex]["errorOccurrences"] = data[errorListIndex]["errorOccurrences"] - MAX_ERRORS_TO_DISPLAY;
-    }
-
-    /*
-     * Form the required number of error/warning cards table structure.
-     * The size of 'data' is the number of error/warning cards required.
-     */
-    var eachCardTemplateScript = $("#error-card-table-template").html();
-    var eachCardTemplate = Handlebars.compile(eachCardTemplateScript);
-    var cardsCompiledHtml = eachCardTemplate(data);
-    $("#error-cards").html(cardsCompiledHtml);
-
-    for (errorListIndex in data) {
-        // Hide '...and xx more' message if occurrences <= 0
-        if (data[errorListIndex]["errorOccurrences"] <= 0) {
-            $(".show-more-" + errorListIndex).hide();
+        // Get the correct count of error occurrences to show in text '...and xx more'
+        for (errorListIndex in data) {
+            data[errorListIndex]["errorOccurrences"] = data[errorListIndex]["errorOccurrences"] - MAX_ERRORS_TO_DISPLAY;
         }
-        // Calculate the count of errors and warnings.
-        if (data[errorListIndex]["errorId"].startsWith("E")) {
-            errorCount++;
-        } else if (data[errorListIndex]["errorId"].startsWith("W")) {
-            warningCount++;
-        }
-
-        // Fill each error/warning card table data
-        var cardBodyTemplateScript = $("#error-card-body-template").html();
-        var cardBodyTemplate = Handlebars.compile(cardBodyTemplateScript);
-
-        showLessErrorList[errorListIndex] = {};
 
         /*
-         * At first, we will display less number of rows in each error/warning table.
-         * 'MAX_ERRORS_TO_DISPLAY' is the number of error/warning occurrences to display.
-         * 'showLessErrorList' will store each error occurrences data size to <= 'MAX_ERRORS_TO_DISPLAY'
+         * Form the required number of error/warning cards table structure.
+         * The size of 'data' is the number of error/warning cards required.
          */
-        for (numErrorsIndex in data[errorListIndex]["viewIterationErrorsModelList"]) {
-            if (numErrorsIndex < MAX_ERRORS_TO_DISPLAY) {
-                showLessErrorList[errorListIndex][numErrorsIndex] = data[errorListIndex]["viewIterationErrorsModelList"][numErrorsIndex];
+        var eachCardTemplateScript = $("#error-card-table-template").html();
+        var eachCardTemplate = Handlebars.compile(eachCardTemplateScript);
+        var cardsCompiledHtml = eachCardTemplate(data);
+        $("#error-cards").html(cardsCompiledHtml);
+
+        for (errorListIndex in data) {
+            // Hide '...and xx more' message if occurrences <= 0
+            if (data[errorListIndex]["errorOccurrences"] <= 0) {
+                $(".show-more-" + errorListIndex).hide();
             }
+            // Calculate the count of errors and warnings.
+            if (data[errorListIndex]["errorId"].startsWith("E")) {
+                errorCount++;
+            } else if (data[errorListIndex]["errorId"].startsWith("W")) {
+                warningCount++;
+            }
+
+            // Fill each error/warning card table data
+            var cardBodyTemplateScript = $("#error-card-body-template").html();
+            var cardBodyTemplate = Handlebars.compile(cardBodyTemplateScript);
+
+            showLessErrorList[errorListIndex] = {};
+
+            /*
+             * At first, we will display less number of rows in each error/warning table.
+             * 'MAX_ERRORS_TO_DISPLAY' is the number of error/warning occurrences to display.
+             * 'showLessErrorList' will store each error occurrences data size to <= 'MAX_ERRORS_TO_DISPLAY'
+             */
+            for (numErrorsIndex in data[errorListIndex]["viewIterationErrorsModelList"]) {
+                if (numErrorsIndex < MAX_ERRORS_TO_DISPLAY) {
+                    showLessErrorList[errorListIndex][numErrorsIndex] = data[errorListIndex]["viewIterationErrorsModelList"][numErrorsIndex];
+                }
+            }
+
+            /*
+             * 'setupExportData' method sets all the rows of each table to be exported as csv file.
+             * Creates a click event for each download button.
+             */
+            setupExportData(errorListIndex, cardBodyTemplate);
+
+            // Show less number of rows in each table.
+            var bodyCompiledHtml = cardBodyTemplate(showLessErrorList[errorListIndex]);
+            $("#error-card-body-" + errorListIndex).html(bodyCompiledHtml);
         }
 
-        /*
-         * 'setupExportData' method sets all the rows of each table to be exported as csv file.
-         * Creates a click event for each download button.
-         */
-        setupExportData(errorListIndex, cardBodyTemplate);
+        $(".issues-page-loader").hide();
 
-        // Show less number of rows in each table.
-        var bodyCompiledHtml = cardBodyTemplate(showLessErrorList[errorListIndex]);
-        $("#error-card-body-" + errorListIndex).html(bodyCompiledHtml);
-    }
+        $("#error-count").text(errorCount);
+        $("#warning-count").text(warningCount);
 
-    $(".issues-page-loader").hide();
-
-    $("#error-count").text(errorCount);
-    $("#warning-count").text(warningCount);
-
-    // Add a click event listener for downloading all the tables data saved in 'allTablesData'
-    allTablesData = exportDataHeader + allTablesData;
-    var instance = new TableExport($('<div>')); // Instantiate TableExport
-    $('#download-all-button').on('click', function(e) {
-                             // File data,   mimeType,  filename,                   fileExtension
-        instance.export2file(allTablesData, 'text/csv', 'iteration_' + iterationId, '.csv');
+        // Add a click event listener for downloading all the tables data saved in 'allTablesData'
+        allTablesData = exportDataHeader + allTablesData;
+        var instance = new TableExport($('<div>')); // Instantiate TableExport
+        $('#download-all-button').on('click', function(e) {
+                                 // File data,   mimeType,  filename,                   fileExtension
+            instance.export2file(allTablesData, 'text/csv', 'iteration_' + iterationId, '.csv');
+        });
     });
-});
-
+}
 // On clicking '...and xx more' text, this method will show all the occurrences of that error/warning
 function showEntireList(errorIndex) {
     var cardDataTemplateScript = $("#error-card-body-template").html();
@@ -215,4 +220,5 @@ function getUrlParameter(param) {
             return parameterName[1];
         }
     }
+    return '';
 }

--- a/src/main/resources/webroot/custom-js/iteration.js
+++ b/src/main/resources/webroot/custom-js/iteration.js
@@ -30,7 +30,7 @@ var allTablesData = '';
 
 var server = window.location.protocol + "//" + window.location.host;
 $(".feed-page-loader").show();
-if(iterationId != -1) {
+if (iterationId != -1) {
     $(".issues-page-loader").show();
 } else {
     $(".issues-page-loader").hide();
@@ -69,7 +69,7 @@ clipboard.on('error', function(e) {
     hideTooltip(btn);
 });
 
-if(iterationId != -1) {
+if (iterationId != -1) {
 // Get the list of errors/warnings and list of their occurrences from server for a particular 'iterationId'.
     $.get(server + "/api/gtfs-rt-feed/" + iterationId + "/iterationErrors").done(function (data) {
 

--- a/src/main/resources/webroot/custom-js/monitoring.js
+++ b/src/main/resources/webroot/custom-js/monitoring.js
@@ -116,6 +116,7 @@ function updateMonitorData(id, data) {
     updatePaginationLogData(id, data["viewGtfsRtFeedErrorCountModelList"]);
     updateSummaryTables(id, data["viewErrorSummaryModelList"]);
     updateLogTables(id, data["viewErrorLogModelList"]);
+    updateMostRecentFeedLink(id, data["viewErrorLogModelList"]);
 }
 
 function updateSummaryTables(index, data) {
@@ -172,6 +173,21 @@ function handleToggledData(index, data, summaryTable) {
             showOrHideError(index, errorId); // Toggle change event handler
         });
     });
+}
+
+function updateMostRecentFeedLink(id, data) {
+    $("#most-recent-iteration-"+id).children("a").first()
+    .attr("href", "iteration.html?iteration={{iterationId}}&sessionIteration={{rowId}}&gtfsRtId={{gtfsRtId}}");
+    var mostRecentIterationScript = $("#most-recent-iteration-"+id).html();
+    var mostRecentResponseTemplate = Handlebars.compile(mostRecentIterationScript);
+    var mostRecentResponseHtml;
+    if(data != null && data != '' && data != undefined) {
+        mostRecentResponseHtml = mostRecentResponseTemplate(data[0]);
+    } else {
+        var context = {iterationId : -1, rowId: requests[id], gtfsRtId: id};
+        mostRecentResponseHtml = mostRecentResponseTemplate(context);
+    }
+    $("#most-recent-iteration-"+id).html(mostRecentResponseHtml);
 }
 
 function updateLogTables(index, data) {

--- a/src/main/resources/webroot/monitoring.html
+++ b/src/main/resources/webroot/monitoring.html
@@ -131,6 +131,11 @@
                         Unique responses:
                         <span class="info-text" id="responses-{{gtfsRtId}}">0</span>
                     </div>
+                    <div class="col-md-4 pull-right">
+                        <div id="most-recent-iteration-{{gtfsRtId}}">
+                            <a href="iteration.html?iteration=-1&sessionIteration=0&gtfsRtId={{gtfsRtId}}" target="_blank">Most recent response</a>
+                        </div>
+                    </div>
                 </div>
                 <hr/>
                 <table class="table">
@@ -191,7 +196,7 @@
         <td>{{title}}</td>
 
         <td>{{severity}}</td>
-        <td><a href="iteration.html?iteration={{lastIterationId}}&sessionIteration={{lastRowId}}" target="_blank">{{lastRowId}}</a></td>
+        <td><a href="iteration.html?iteration={{lastIterationId}}&sessionIteration={{lastRowId}}&gtfsRtId={{gtfsRtId}}" target="_blank">{{lastRowId}}</a></td>
         <td title="Time zone: {{timeZone}}">{{formattedTimestamp}} ({{lastFeedTime}})</td>
 
         <td>{{count}}</td>
@@ -203,7 +208,7 @@
 <script id="feed-monitor-log-row-template" type="text/x-handlebars-template">
     {{#each this}}
     <tr>
-        <td><a href="iteration.html?iteration={{iterationId}}&sessionIteration={{rowId}}" target="_blank">{{rowId}}</a></td>
+        <td><a href="iteration.html?iteration={{iterationId}}&sessionIteration={{rowId}}&gtfsRtId={{gtfsRtId}}" target="_blank">{{rowId}}</a></td>
         <td><a href="https://github.com/CUTR-at-USF/gtfs-realtime-validator/blob/master/RULES.md#{{id}}" target="_blank">{{id}}</a></td>
         <td>{{title}}</td>
 


### PR DESCRIPTION
**Summary:**

Now a link to check the feed message available in the error summary area of the feed monitoring page.

**Expected behavior:** 

The link will open an iteration details screen which shows the latest feed message if there are no errors and the latest feed message along with errors if any.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Run the unit tests with `mvn test` to make sure you didn't break anything
- [X] Format the title like "Fix #issue - short description of fix and changes"
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)
