### PR TITLE
Fix #255 - E047 - Allow vehicle to be assigned to multiple trips in same block

### DIFF
--- a/gtfs-realtime-validator-lib/pom.xml
+++ b/gtfs-realtime-validator-lib/pom.xml
@@ -37,7 +37,7 @@
             <artifactId>commons-cli</artifactId>
             <version>1.4</version>
         </dependency>
-        <!-- For Bidirectional HashMap (i.e., BiMap) (see E047) -->
+        <!-- For ordering of stop_time_updates (see E002) and @Immutable (See ViewMessageDetailsModel) -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/CrossFeedDescriptorValidator.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/CrossFeedDescriptorValidator.java
@@ -17,8 +17,6 @@
 
 package edu.usf.cutr.gtfsrtvalidator.lib.validation.rules;
 
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
 import com.google.transit.realtime.GtfsRealtime;
 import edu.usf.cutr.gtfsrtvalidator.lib.model.MessageLogModel;
 import edu.usf.cutr.gtfsrtvalidator.lib.model.OccurrenceModel;
@@ -57,13 +55,17 @@ public class CrossFeedDescriptorValidator implements FeedEntityValidator {
         List<OccurrenceModel> e047List = new ArrayList<>();
 
         // key is trip_id from TripUpdates feed, value is vehicle.id
-        BiMap<String, String> tripUpdates = HashBiMap.create();
+        HashMap<String, String> tripUpdatesTripIdToVehicleId = new HashMap<>();
+        // key is vehicle.id from TripUpdates feed, value is trip_id
+        HashMap<String, String> tripUpdatesVehicleIdToTripId = new HashMap<>();
         // A set of trips (key = trip_id) that don't have any vehicle.ids
         Set<String> tripsWithoutVehicles = new HashSet<>();
         int tripUpdateCount = 0;
 
         // key is vehicle_id from VehiclePositions feed, value is trip_id
-        BiMap<String, String> vehiclePositions = HashBiMap.create();
+        HashMap<String, String> vehiclePositionsVehicleIdToTripId = new HashMap<>();
+        // key is trip_id from VehiclePositions feed, value is vehicle_id
+        HashMap<String, String> vehiclePositionsTripIdToVehicleId = new HashMap<>();
         // A set of vehicles (key = vehicle.id) that don't have any trip_ids
         Set<String> vehiclesWithoutTrips = new HashSet<>();
         int vehiclePositionCount = 0;
@@ -83,7 +85,8 @@ public class CrossFeedDescriptorValidator implements FeedEntityValidator {
                 } else {
                     // Trip has a vehicle.id - add it to the HashBiMap
                     try {
-                        tripUpdates.put(tripId, vehicleId);
+                        tripUpdatesTripIdToVehicleId.put(tripId, vehicleId);
+                        tripUpdatesVehicleIdToTripId.put(vehicleId, tripId);
                     } catch (IllegalArgumentException e) {
                         // TODO - Maybe log this as error under new rule? - see https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/33
                         // However, there are legitimate cases that will end up here - see https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/255
@@ -105,7 +108,8 @@ public class CrossFeedDescriptorValidator implements FeedEntityValidator {
                 } else {
                     // Vehicle has a trip_id - add it to the HashBiMap
                     try {
-                        vehiclePositions.put(vehicleId, tripId);
+                        vehiclePositionsVehicleIdToTripId.put(vehicleId, tripId);
+                        vehiclePositionsTripIdToVehicleId.put(tripId, vehicleId);
                     } catch (IllegalArgumentException e) {
                         // TODO - We should log this as error under new rule - see https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/38
                         _log.error("Error adding vehicle.id " + vehicleId + " -> trip_id " + tripId + " to VehiclePositions HashBiMap.  Vehicle exists twice in feed, or more than one vehicle is assigned to same trip. " + e);
@@ -130,38 +134,36 @@ public class CrossFeedDescriptorValidator implements FeedEntityValidator {
          * Note that we still need to check vehiclesWithoutTrips and tripsWithoutVehicles, as these trips/vehicles can't exist in HashBiMaps.
          * See https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/241#issuecomment-313194304.
          */
-        BiMap<String, String> tripUpdatesInverse = tripUpdates.inverse();
-        BiMap<String, String> vehiclePositionsInverse = vehiclePositions.inverse();
 
         // Check all trips that contained a vehicle
-        for (Map.Entry<String, String> trip : tripUpdates.entrySet()) {
-            if (!vehiclePositionsInverse.containsKey(trip.getKey())) {
+        for (Map.Entry<String, String> trip : tripUpdatesTripIdToVehicleId.entrySet()) {
+            if (!vehiclePositionsTripIdToVehicleId.containsKey(trip.getKey())) {
                 // W003 - TripUpdates feed has a trip_id that's not in VehiclePositions feed
                 RuleUtils.addOccurrence(W003, "trip_id " + trip.getKey() + " is in TripUpdates but not in VehiclePositions feed", w003List, _log);
             }
-            if (!vehiclePositions.containsKey(trip.getValue()) && !vehiclesWithoutTrips.contains(trip.getValue())) {
+            if (!vehiclePositionsVehicleIdToTripId.containsKey(trip.getValue()) && !vehiclesWithoutTrips.contains(trip.getValue())) {
                 // W003 - TripUpdates feed has a vehicle_id that's not in VehiclePositions feed
                 RuleUtils.addOccurrence(W003, "vehicle_id " + trip.getValue() + " is in TripUpdates but not in VehiclePositions feed", w003List, _log);
             }
-            checkE047TripUpdates(trip, vehiclePositionsInverse, e047List);
+            checkE047TripUpdates(trip, vehiclePositionsTripIdToVehicleId, e047List);
         }
 
         // Check all vehicles that contained a trip
-        for (Map.Entry<String, String> vehiclePosition : vehiclePositions.entrySet()) {
-            if (!tripUpdatesInverse.containsKey(vehiclePosition.getKey())) {
+        for (Map.Entry<String, String> vehiclePosition : vehiclePositionsVehicleIdToTripId.entrySet()) {
+            if (!tripUpdatesVehicleIdToTripId.containsKey(vehiclePosition.getKey())) {
                 // W003 - VehiclePositions has a vehicle_id that's not in TripUpdates feed
                 RuleUtils.addOccurrence(W003, "vehicle_id " + vehiclePosition.getKey() + " is in VehiclePositions but not in TripUpdates feed", w003List, _log);
             }
-            if (!tripUpdates.containsKey(vehiclePosition.getValue()) && !tripsWithoutVehicles.contains(vehiclePosition.getValue())) {
+            if (!tripUpdatesTripIdToVehicleId.containsKey(vehiclePosition.getValue()) && !tripsWithoutVehicles.contains(vehiclePosition.getValue())) {
                 // W003 - VehiclePositions has a trip_id that's not in the TripUpdates feed
                 RuleUtils.addOccurrence(W003, "trip_id " + vehiclePosition.getValue() + " is in VehiclePositions but not in TripUpdates feed", w003List, _log);
             }
-            checkE047VehiclePositions(vehiclePosition, tripUpdatesInverse, e047List);
+            checkE047VehiclePositions(vehiclePosition, tripUpdatesVehicleIdToTripId, e047List);
         }
 
         // Check all trips that did NOT contain a vehicle
         for (String trip_id : tripsWithoutVehicles) {
-            if (!vehiclePositionsInverse.containsKey(trip_id)) {
+            if (!vehiclePositionsTripIdToVehicleId.containsKey(trip_id)) {
                 // W003 - TripUpdates feed has a trip_id that's not in VehiclePositions feed
                 RuleUtils.addOccurrence(W003, "trip_id " + trip_id + " is in TripUpdates but not in VehiclePositions feed", w003List, _log);
             }
@@ -169,7 +171,7 @@ public class CrossFeedDescriptorValidator implements FeedEntityValidator {
 
         // Check all vehicles that did NOT contain a trip
         for (String vehicle_id : vehiclesWithoutTrips) {
-            if (!tripUpdatesInverse.containsKey(vehicle_id)) {
+            if (!tripUpdatesVehicleIdToTripId.containsKey(vehicle_id)) {
                 // W003 - VehiclePositions has a vehicle_id that's not in TripUpdates feed
                 RuleUtils.addOccurrence(W003, "vehicle_id " + vehicle_id + " is in VehiclePositions but not in TripUpdates feed", w003List, _log);
             }
@@ -211,7 +213,7 @@ public class CrossFeedDescriptorValidator implements FeedEntityValidator {
      * @param vehiclePositionsInverse An inverse map of a VehiclePositions feed, with keys that represent the trip_ids that each VehiclePosition contains, and the value being the VehiclePosition vehicle.id that contains the trip_id
      * @param errors                  the list to add the errors to
      */
-    private void checkE047TripUpdates(Map.Entry<String, String> trip, BiMap<String, String> vehiclePositionsInverse, List<OccurrenceModel> errors) {
+    private void checkE047TripUpdates(Map.Entry<String, String> trip, HashMap<String, String> vehiclePositionsInverse, List<OccurrenceModel> errors) {
         String vehiclePositionsVehicleId = vehiclePositionsInverse.get(trip.getKey());
         String tripUpdatesVehicleId = trip.getValue();
         if (!StringUtils.isEmpty(vehiclePositionsVehicleId)) {
@@ -228,7 +230,7 @@ public class CrossFeedDescriptorValidator implements FeedEntityValidator {
      * @param tripUpdatesInverse An inverse map of a TripUpdates feed, with keys that represent the vehicle_ids that each TripUpdate contains, and the value being the TripUpdate trip_id that contains the vehicle.id
      * @param errors             the list to add the errors to
      */
-    private void checkE047VehiclePositions(Map.Entry<String, String> vehicle, BiMap<String, String> tripUpdatesInverse, List<OccurrenceModel> errors) {
+    private void checkE047VehiclePositions(Map.Entry<String, String> vehicle, HashMap<String, String> tripUpdatesInverse, List<OccurrenceModel> errors) {
         String tripUpdatesTripId = tripUpdatesInverse.get(vehicle.getKey());
         String vehiclePositionsTripId = vehicle.getValue();
         if (!StringUtils.isEmpty(tripUpdatesTripId)) {

--- a/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/CrossFeedDescriptorValidatorTest.java
+++ b/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/CrossFeedDescriptorValidatorTest.java
@@ -83,8 +83,9 @@ public class CrossFeedDescriptorValidatorTest extends FeedMessageTest {
 
         /**
          * Clear the VehiclePosition trip_id, and clear the TripUpdates vehicle.id, and add two versions of each
-         * (to make sure we detect HashBiMap IllegalArgumentException - see https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/241#issuecomment-313194304)
-         * - 4 warnings.
+         * (to make sure we catch this case - see
+         * https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/241#issuecomment-313194304, although we're no
+         * longer using HashBiMaps) - 4 warnings.
          */
         vehicleDescriptorBuilder.clearId();
         tripDescriptorBuilder.setTripId("100");
@@ -120,8 +121,8 @@ public class CrossFeedDescriptorValidatorTest extends FeedMessageTest {
 
         /**
          * Set the VehiclePosition trip_id to empty string, and set the TripUpdates vehicle.id to empty string, and add two versions of each
-         * (to make sure we detect HashBiMap IllegalArgumentException - see https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/241#issuecomment-313194304)
-         * - 4 warnings.
+         * (to make sure we catch this case - see https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/241#issuecomment-313194304, although we're no
+         * longer using HashBiMaps) - 4 warnings.
          */
         vehicleDescriptorBuilder.setId("");
         tripDescriptorBuilder.setTripId("100");
@@ -286,10 +287,10 @@ public class CrossFeedDescriptorValidatorTest extends FeedMessageTest {
         TestUtils.assertResults(expected, results);
 
         /**
-         * Set the VehiclePosition trip_id to empty string (and create two entities like this, to make sure we detect
-         * HashBiMap IllegalArgumentException - see https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/241#issuecomment-313194304),
-         * and change TripUpdate to trip_id 1.1 and vehicle_id 1 - 0 mismatch, so 0 errors.
-         * Also, 4 warnings for W003 (2 for TripUpdate, and 1 for each VehiclePosition).
+         * Set the VehiclePosition trip_id to empty string (and create two entities like this, to make sure catch this
+         * case - see https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/241#issuecomment-313194304, although
+         * we're no longer using HashBiMaps), and change TripUpdate to trip_id 1.1 and vehicle_id 1 - 0 mismatch, so 0
+         * errors. Also, 4 warnings for W003 (2 for TripUpdate, and 1 for each VehiclePosition).
          */
         vehicleB.setId("45");
         tripB.setTripId("");
@@ -314,9 +315,9 @@ public class CrossFeedDescriptorValidatorTest extends FeedMessageTest {
         TestUtils.assertResults(expected, results);
 
         /**
-         * Clear the VehiclePosition trip_id (and create two entities like this to make sure we detect HashBiMap
-         * IllegalArgumentException - see https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/241#issuecomment-313194304),
-         * while TripUpdate still has trip_id 1.1 and vehicle_id 1 - 0 mismatch, so 0 errors.
+         * Clear the VehiclePosition trip_id (and create two entities like this to make sure we catch this case - see
+         * https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/241#issuecomment-313194304, although we're no
+         * longer using HashBiMaps), while TripUpdate still has trip_id 1.1 and vehicle_id 1 - 0 mismatch, so 0 errors.
          * Also, 4 warnings for W003 (2 for TripUpdate, and 1 for each VehiclePosition).
          */
         vehicleB.setId("45");
@@ -342,9 +343,9 @@ public class CrossFeedDescriptorValidatorTest extends FeedMessageTest {
         TestUtils.assertResults(expected, results);
 
         /**
-         * Set the TripUpdate vehicle.id to empty string and VehiclePosition trip_id to empty string (and create two entities like this to make sure we detect
-         * HashBiMap IllegalArgumentException - see https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/241#issuecomment-313194304)
-         * - 0 mismatch, so 0 errors.
+         * Set the TripUpdate vehicle.id to empty string and VehiclePosition trip_id to empty string (and create two entities like this to make we
+         * catch this case - see https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/241#issuecomment-313194304, although we're no
+         * longer using HashBiMaps) - 0 mismatch, so 0 errors.
          * Also, 4 warnings for W003 (two for each entity with empty string IDs).
          */
         vehicleB.setId("45");
@@ -381,9 +382,10 @@ public class CrossFeedDescriptorValidatorTest extends FeedMessageTest {
         TestUtils.assertResults(expected, results);
 
         /**
-         * Clear the TripUpdate vehicle.id and VehiclePosition trip_id (and create two entities like this to make sure we detect HashBiMap
-         * IllegalArgumentException - see https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/241#issuecomment-313194304)
-         * - 0 mismatch, so 0 errors.
+         * Clear the TripUpdate vehicle.id and VehiclePosition trip_id (and create two entities like this to make sure
+         * we catch this case - see
+         * https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/241#issuecomment-313194304, although we're no
+         * longer using HashBiMaps) - 0 mismatch, so 0 errors.
          * Also, 4 warnings for W003 (two for each entity with cleared IDs).
          */
         vehicleB.setId("45");

--- a/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/CrossFeedDescriptorValidatorTest.java
+++ b/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/CrossFeedDescriptorValidatorTest.java
@@ -286,34 +286,9 @@ public class CrossFeedDescriptorValidatorTest extends FeedMessageTest {
         TestUtils.assertResults(expected, results);
 
         /**
-         * Change the TripUpdate to have trip_id 6.1 and vehicle.id = 45, while VehiclePosition is changed to have trip_id 7.1 and vehicle_id 45.
-         * Trips 6.1 and 7.1 have the same block_id block.1 (i.e., the same vehicle is going to serve both trips), so having the same vehicle_id is ok - 0 errors.
-         * See https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/255 for details on same vehicle running more than one trip in the same block.
-         * Also 2 occurrences of W003.
-         */
-        vehicleA.setId("45");
-        tripA.setTripId("6.1");
-        tripUpdateBuilder.setVehicle(vehicleA.build());
-        tripUpdateBuilder.setTrip(tripA.build());
-
-        vehicleB.setId("45");
-        tripB.setTripId("7.1");
-        vehiclePositionBuilder.setVehicle(vehicleB.build());
-        vehiclePositionBuilder.setTrip(tripB.build());
-
-        feedEntityBuilder.setTripUpdate(tripUpdateBuilder.build());
-        feedEntityBuilder.setVehicle(vehiclePositionBuilder.build());
-        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
-
-        results = crossFeedDescriptorValidator.validate(TimestampUtils.MIN_POSIX_TIME, gtfsData, gtfsDataMetadata, null, null, feedMessageBuilder.build());
-        expected.clear();
-        expected.put(ValidationRules.W003, 2);
-        TestUtils.assertResults(expected, results);
-
-        /**
          * Set the VehiclePosition trip_id to empty string (and create two entities like this, to make sure we detect
          * HashBiMap IllegalArgumentException - see https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/241#issuecomment-313194304),
-         * while TripUpdate still has trip_id 1.1 and vehicle_id 1 - 0 mismatch, so 0 errors.
+         * and change TripUpdate to trip_id 1.1 and vehicle_id 1 - 0 mismatch, so 0 errors.
          * Also, 4 warnings for W003 (2 for TripUpdate, and 1 for each VehiclePosition).
          */
         vehicleB.setId("45");
@@ -442,6 +417,32 @@ public class CrossFeedDescriptorValidatorTest extends FeedMessageTest {
         results = crossFeedDescriptorValidator.validate(TimestampUtils.MIN_POSIX_TIME, gtfsData, gtfsDataMetadata, null, null, feedMessageBuilder.build());
         expected.clear();
         expected.put(ValidationRules.W003, 4);
+        TestUtils.assertResults(expected, results);
+
+        /**
+         * Change the TripUpdate to have trip_id 6.1 and vehicle.id = 45, while VehiclePosition is changed to have trip_id 7.1 and vehicle_id 45.
+         * Trips 6.1 and 7.1 have the same block_id block.1 (i.e., the same vehicle is going to serve both trips), so having the same vehicle_id is ok - 0 errors.
+         * See https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/255 for details on same vehicle running more than one trip in the same block.
+         * Also 2 occurrences of W003.
+         */
+        vehicleA.setId("45");
+        tripA.setTripId("6.1");
+        tripUpdateBuilder.setVehicle(vehicleA.build());
+        tripUpdateBuilder.setTrip(tripA.build());
+
+        vehicleB.setId("45");
+        tripB.setTripId("7.1");
+        vehiclePositionBuilder.setVehicle(vehicleB.build());
+        vehiclePositionBuilder.setTrip(tripB.build());
+
+        feedEntityBuilder.setTripUpdate(tripUpdateBuilder.build());
+        feedEntityBuilder.setVehicle(vehiclePositionBuilder.build());
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+        feedMessageBuilder.removeEntity(1); // Remove the additional entity created in previous tests
+
+        results = crossFeedDescriptorValidator.validate(TimestampUtils.MIN_POSIX_TIME, gtfsData, gtfsDataMetadata, null, null, feedMessageBuilder.build());
+        expected.clear();
+        expected.put(ValidationRules.W003, 2);
         TestUtils.assertResults(expected, results);
     }
 }

--- a/gtfs-realtime-validator-webapp/pom.xml
+++ b/gtfs-realtime-validator-webapp/pom.xml
@@ -71,13 +71,6 @@
             <version>1.4</version>
         </dependency>
 
-        <!-- For Bidirectional HashMap (i.e., BiMap) (see E047) -->
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>22.0</version>
-        </dependency>
-
         <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>


### PR DESCRIPTION
~~**Please do not merge - work in progress**~~

**Summary:**

The same vehicle should be able to be assigned to more than one trip if the trips are part of the same block (i.e., the vehicle will serve one trip and then the next trip)

* Add unit test assertion that shows incorrect error logged for E047 (prior to this PR), as described in https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/255
* Remove BiMap and replace with another pair of HashMaps
* Add check for same vehicle serving multiple trips with the same block for E047
* Also fix error in comment that mistakenly referenced E036
* Clean up left-over references to HashBiMaps, but keep TODO comments for where new rules should be inserted