### PR TITLE
WIP - Fix #299 - Add "About" menu with Maven version numbers

### DIFF
--- a/gtfs-realtime-validator-lib/pom.xml
+++ b/gtfs-realtime-validator-lib/pom.xml
@@ -106,6 +106,24 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <!-- Used w/ VersionUtil.java to get the Maven version number at runtime -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>templating-maven-plugin</artifactId>
+                    <version>1.0.0</version>
+                    <executions>
+                        <execution>
+                            <id>generate-version-class</id>
+                            <goals>
+                                <goal>filter-sources</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -191,6 +209,34 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+
+            <!-- Used w/ VersionUtil.java to get the Maven version number at runtime -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>templating-maven-plugin</artifactId>
+                <version>1.0.0</version>
+            </plugin>
+
+            <!-- Used w/ VersionUtil.java to get the Git commit ID at runtime -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+                <version>1.4</version>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>create</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <doCheck>false</doCheck>
+                    <doUpdate>false</doUpdate>
+                    <revisionOnScmFailure>UNKNOWN</revisionOnScmFailure>
+                    <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/gtfs-realtime-validator-lib/src/main/java-templates/edu/usf/cutr/gtfsrtvalidator/VersionUtil.java
+++ b/gtfs-realtime-validator-lib/src/main/java-templates/edu/usf/cutr/gtfsrtvalidator/VersionUtil.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2018 University of South Florida (sjbarbeau@gmail.com)
+ *
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.usf.cutr.gtfsrtvalidator;
+
+import edu.usf.cutr.gtfsrtvalidator.lib.model.VersionModel;
+
+/**
+ * Class used with the templating-maven-plugin to get Maven version numbers at runtime. See https://stackoverflow.com/a/36628755/937715
+ */
+public class VersionUtil {
+
+    private static final String VERSION = "${project.version}";
+    private static final String GROUPID = "${project.groupId}";
+    private static final String ARTIFACTID = "${project.artifactId}";
+    private static final String REVISION = "${buildNumber}";
+
+    public static VersionModel getVersion() {
+        return new VersionModel(VERSION, GROUPID, ARTIFACTID, REVISION);
+    }
+}

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/Main.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/Main.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2017 Nipuna Gunathilake, University of South Florida
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/batch/BatchProcessor.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/batch/BatchProcessor.java
@@ -3,7 +3,7 @@
  *
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ErrorMessageModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ErrorMessageModel.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/GtfsFeedIterationModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/GtfsFeedIterationModel.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/GtfsFeedModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/GtfsFeedModel.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/GtfsRtFeedIterationModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/GtfsRtFeedIterationModel.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/GtfsRtFeedIterationString.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/GtfsRtFeedIterationString.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/GtfsRtFeedModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/GtfsRtFeedModel.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/MessageLogModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/MessageLogModel.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/OccurrenceModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/OccurrenceModel.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/SessionModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/SessionModel.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ValidationRule.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ValidationRule.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/VersionModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/VersionModel.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2018 University of South Florida (sjbarbeau@gmail.com)
+ *
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.usf.cutr.gtfsrtvalidator.lib.model;
+
+/**
+ * A model class to hold the information generated at build time in VersionUtil. See https://stackoverflow.com/a/36628755/937715
+ */
+public class VersionModel {
+
+    private String mVersion;
+    private String mGroupId;
+    private String mArtifactId;
+    private String mRevision;
+
+    public VersionModel() {
+
+    }
+
+    public VersionModel(String version, String groupId, String artifactId, String revision) {
+        mVersion = version;
+        mGroupId = groupId;
+        mArtifactId = artifactId;
+        mRevision = revision;
+    }
+
+    public String getVersion() {
+        return mVersion;
+    }
+
+    public String getGroupId() {
+        return mGroupId;
+    }
+
+    public String getArtifactId() {
+        return mArtifactId;
+    }
+
+    public String getRevision() {
+        return mRevision;
+    }
+
+    public void setVersion(String version) {
+        this.mVersion = version;
+    }
+
+    public void setGroupId(String groupId) {
+        this.mGroupId = mGroupId;
+    }
+
+    public void setArtifactId(String artifactId) {
+        this.mArtifactId = mArtifactId;
+    }
+
+    public void setRevision(String revision) {
+        this.mRevision = revision;
+    }
+
+    @Override
+    public String toString() {
+        return "VersionModel{" +
+                "version='" + mVersion + '\'' +
+                ", groupId='" + mGroupId + '\'' +
+                ", artifactId='" + mArtifactId + '\'' +
+                ", revision='" + mRevision + '\'' +
+                '}';
+    }
+}

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewErrorLogModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewErrorLogModel.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewErrorSummaryModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewErrorSummaryModel.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewFeedIterationsCount.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewFeedIterationsCount.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewFeedMessageModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewFeedMessageModel.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewFeedUniqueResponseCount.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewFeedUniqueResponseCount.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewGtfsErrorCountModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewGtfsErrorCountModel.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewGtfsRtFeedErrorCountModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewGtfsRtFeedErrorCountModel.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewIterationErrorsModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewIterationErrorsModel.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewMessageDetailsModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewMessageDetailsModel.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/combined/CombinedIterationMessageModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/combined/CombinedIterationMessageModel.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/combined/CombinedMessageOccurrenceModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/combined/CombinedMessageOccurrenceModel.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/helper/ErrorListHelperModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/helper/ErrorListHelperModel.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/helper/IterationErrorListHelperModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/helper/IterationErrorListHelperModel.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/helper/MergeMonitorData.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/helper/MergeMonitorData.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/util/GtfsUtils.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/util/GtfsUtils.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/util/RuleUtils.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/util/RuleUtils.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/util/SortUtils.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/util/SortUtils.java
@@ -3,7 +3,7 @@
  *
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/util/TimestampUtils.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/util/TimestampUtils.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/GtfsMetadata.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/GtfsMetadata.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/IterationStatistics.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/IterationStatistics.java
@@ -3,7 +3,7 @@
  *
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/ValidationRules.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/ValidationRules.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011-2017 Nipuna Gunathilake, University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/gtfs/StopLocationTypeValidator.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/gtfs/StopLocationTypeValidator.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/interfaces/FeedEntityValidator.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/interfaces/FeedEntityValidator.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/interfaces/GtfsFeedValidator.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/interfaces/GtfsFeedValidator.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/CrossFeedDescriptorValidator.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/CrossFeedDescriptorValidator.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/FrequencyTypeOneValidator.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/FrequencyTypeOneValidator.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/FrequencyTypeZeroValidator.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/FrequencyTypeZeroValidator.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/HeaderValidator.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/HeaderValidator.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/StopTimeUpdateValidator.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/StopTimeUpdateValidator.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011-2017 Nipuna Gunathilake, University of South Florida
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/StopValidator.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/StopValidator.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/TimestampValidator.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/TimestampValidator.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011-2017 Nipuna Gunathilake, University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/TripDescriptorValidator.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/TripDescriptorValidator.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/VehicleValidator.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/VehicleValidator.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/BatchTest.java
+++ b/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/BatchTest.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/FeedMessageTest.java
+++ b/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/FeedMessageTest.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/UtilTest.java
+++ b/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/UtilTest.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/CrossFeedDescriptorValidatorTest.java
+++ b/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/CrossFeedDescriptorValidatorTest.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/FrequencyTypeOneValidatorTest.java
+++ b/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/FrequencyTypeOneValidatorTest.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/HeaderValidatorTest.java
+++ b/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/HeaderValidatorTest.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/StopLocationTypeValidatorTest.java
+++ b/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/StopLocationTypeValidatorTest.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/StopTimeUpdateValidatorTest.java
+++ b/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/StopTimeUpdateValidatorTest.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/StopValidatorTest.java
+++ b/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/StopValidatorTest.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/TimestampValidatorTest.java
+++ b/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/TimestampValidatorTest.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/TripDescriptorValidatorTest.java
+++ b/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/TripDescriptorValidatorTest.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/VehicleValidatorTest.java
+++ b/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/VehicleValidatorTest.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/util/TestUtils.java
+++ b/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/util/TestUtils.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/Main.java
+++ b/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/Main.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2015-2017 Nipuna Gunathilake, University of South Florida
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsFeed.java
+++ b/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsFeed.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsRtFeed.java
+++ b/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsRtFeed.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/VersionApi.java
+++ b/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/VersionApi.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2011 Nipuna Gunathilake.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.usf.cutr.gtfsrtvalidator.api.resource;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.usf.cutr.gtfsrtvalidator.VersionUtil;
+import edu.usf.cutr.gtfsrtvalidator.lib.model.VersionModel;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/version")
+public class VersionApi {
+
+    private static final org.slf4j.Logger _log = LoggerFactory.getLogger(VersionApi.class);
+
+    // A call to `/api/version` returns the Maven version information for this project
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public VersionModel getVersion() throws JsonProcessingException {
+        _log.info(VersionUtil.getVersion().toString());
+        //return mObjectMapper.writeValueAsString(VersionUtil.getVersion());
+        return VersionUtil.getVersion();
+    }
+}

--- a/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/background/BackgroundTask.java
+++ b/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/background/BackgroundTask.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 Nipuna Gunathilake, University of South Florida
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/db/GTFSDB.java
+++ b/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/db/GTFSDB.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2015 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/helper/DBHelper.java
+++ b/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/helper/DBHelper.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/helper/HttpMessageHelper.java
+++ b/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/helper/HttpMessageHelper.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/helper/QueryHelper.java
+++ b/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/helper/QueryHelper.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/servlets/GetFeedJSON.java
+++ b/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/servlets/GetFeedJSON.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/util/FileUtil.java
+++ b/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/util/FileUtil.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011-2018 Nipuna Gunathilake, University of South Florida (sjbarbeau@gmail.com)
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/util/ProtoBufUtils.java
+++ b/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/util/ProtoBufUtils.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2011 Nipuna Gunathilake.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+  * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-webapp/src/main/resources/webroot/custom-js/index.js
+++ b/gtfs-realtime-validator-webapp/src/main/resources/webroot/custom-js/index.js
@@ -23,6 +23,11 @@ var enableShapes;
 
 var server = window.location.protocol + "//" + window.location.host;
 
+
+function about() {
+
+}
+
 function addInput(){
     if (counter == limit)  {
         alert("You have reached the limit of adding " + counter + " inputs");

--- a/gtfs-realtime-validator-webapp/src/main/resources/webroot/error.html
+++ b/gtfs-realtime-validator-webapp/src/main/resources/webroot/error.html
@@ -3,7 +3,7 @@
   ~ Copyright (C) 2011 Nipuna Gunathilake.
   ~ All rights reserved.
   ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ Licensed under the Apache License, VersionModel 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~

--- a/gtfs-realtime-validator-webapp/src/main/resources/webroot/index.html
+++ b/gtfs-realtime-validator-webapp/src/main/resources/webroot/index.html
@@ -24,7 +24,7 @@
         </div>
         <div class="collapse navbar-collapse">
             <ul class="nav navbar-nav pull-right">
-                <li><a href="#">About</a></li>
+                <li><a href="#" role="button" onClick="about();">About</a></li>
                 <li><a href="#">Help</a></li>
                 <li><a href="#">Contact Us</a></li>
             </ul>

--- a/gtfs-realtime-validator-webapp/src/main/resources/webroot/loading.html
+++ b/gtfs-realtime-validator-webapp/src/main/resources/webroot/loading.html
@@ -24,7 +24,7 @@
         </div>
         <div class="collapse navbar-collapse">
             <ul class="nav navbar-nav pull-right">
-                <li><a href="#">About</a></li>
+                <li><a href="#" role="button" onClick="about();">About</a></li>
                 <li><a href="#">Help</a></li>
                 <li><a href="#">Contact Us</a></li>
             </ul>

--- a/gtfs-realtime-validator-webapp/src/test/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsFeedTest.java
+++ b/gtfs-realtime-validator-webapp/src/test/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsFeedTest.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/gtfs-realtime-validator-webapp/src/test/java/edu/usf/cutr/gtfsrtvalidator/test/queries/QueryTest.java
+++ b/gtfs-realtime-validator-webapp/src/test/java/edu/usf/cutr/gtfsrtvalidator/test/queries/QueryTest.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 University of South Florida.
  * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, VersionModel 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/pom.xml
+++ b/pom.xml
@@ -20,4 +20,9 @@
             <url>http://nexus.onebusaway.org/content/groups/public/</url>
         </repository>
     </repositories>
+
+    <scm>
+        <connection>scm:git:https://github.com/CUTR-at-USF/gtfs-realtime-validator.git</connection>
+        <url>https://github.com/CUTR-at-USF/gtfs-realtime-validator.git</url>
+    </scm>
 </project>


### PR DESCRIPTION
**Summary:**

This is initial work towards building an API that exposes Maven version information for the project and showing this info when the user clicks on the "About" link in the webapp page header.

Details:
* Uses `buildnumber-maven-plugin` to get the Git version umber and `templating-maven-plugin` to generate a class that has the Maven version and artifact info (`VersionUtil`) (see https://stackoverflow.com/a/36628755/937715)

Problems:
* `templating-maven-plugin` doesn't play well with IntelliJ. In other words, the project will fail to build in IntelliJ when you check it out because IntelliJ can't find the `VersionUtil` class.  See this IntelliJ issue for implemementing support for `templating-maven-plugin` - https://youtrack.jetbrains.com/oauth?state=%2Fissue%2FIDEA-161010 . The current workaround is to build the project via Maven at the commandline first using `mvn install`, and then IntelliJ will recognize the class.
* `VersionApi.getVersion()` doesn't seem to return the JSON version of the VersionModel when you return just the object (I get an empty response).  Not sure why this isn't working.  Other option is to return a String from this method and serialize to JSON using Jackson `ObjectMapper` directly.

TODO:
- [ ] Determine if `templating-maven-plugin` can be made compatible with IntelliJ.  If not, we may need to switch to another method for getting Maven version information at runtime.
- [ ] Webapp frontend
- [ ] Looks like Find & Replace replaced all the version comment header `Version` with `VersionModel` (after the model class). This needs to be reverted.