### PR TITLE
Fix #154  start time of freq based trip should be immutable.

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -54,6 +54,7 @@ Rules are declared in the [`ValidationRules` class](https://github.com/CUTR-at-U
 | [E050](#E050) | `timestamp` is in the future
 | [E051](#E051) | GTFS-rt `stop_sequence` not found in GTFS data
 | [E052](#E052) | `vehicle.id` is not unique
+| [E053](#E053) | `start_time` for trip has changed
 
 ### Table of Warnings
 
@@ -716,6 +717,16 @@ From [VehiclePosition.VehicleDescriptor](https://github.com/google/transit/blob/
 
 #### References:
 * [`vehicle.id`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-vehicledescriptor)
+
+<a name="E053"/>
+
+### E053 - `start_time` for trip has changed
+
+A frequency based trip should have the same start time in the descriptor.
+
+From [TripUpdate.TripDescriptor](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-tripdescriptor) for `start_time`:
+
+>If the trip corresponds to exact_times=0, then its start_time may be arbitrary, and is initially expected to be the first departure of the trip. Once established, the start_time of this frequency-based exact_times=0 trip should be considered immutable, even if the first departure time changes 
 
 # Warnings
 

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/ValidationRules.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/ValidationRules.java
@@ -267,6 +267,10 @@ public class ValidationRules {
     public static final ValidationRule E052 = new ValidationRule("E052", "ERROR", "vehicle.id is not unique",
             "Each vehicle should have a unique ID",
             "which is used by more than one vehicle in the feed");
+    
+    public static final ValidationRule E053 = new ValidationRule("E053", "ERROR", "start_time for frequency-based trip changed.",
+            "start_time for frequency-based trips",
+            "exact_times=0 must be immutable");
 
     private static List<ValidationRule> mAllRules = new ArrayList<>();
 

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/FrequencyTypeZeroValidator.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/FrequencyTypeZeroValidator.java
@@ -17,6 +17,8 @@
 package edu.usf.cutr.gtfsrtvalidator.lib.validation.rules;
 
 import com.google.transit.realtime.GtfsRealtime;
+import com.google.transit.realtime.GtfsRealtime.TripUpdate;
+
 import edu.usf.cutr.gtfsrtvalidator.lib.model.MessageLogModel;
 import edu.usf.cutr.gtfsrtvalidator.lib.model.OccurrenceModel;
 import edu.usf.cutr.gtfsrtvalidator.lib.model.helper.ErrorListHelperModel;
@@ -27,6 +29,7 @@ import org.onebusaway.gtfs.services.GtfsMutableDao;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import static edu.usf.cutr.gtfsrtvalidator.lib.validation.ValidationRules.*;
@@ -41,16 +44,21 @@ import static edu.usf.cutr.gtfsrtvalidator.lib.validation.ValidationRules.*;
 public class FrequencyTypeZeroValidator implements FeedEntityValidator {
 
     private static final org.slf4j.Logger _log = LoggerFactory.getLogger(FrequencyTypeZeroValidator.class);
-
+    
+    private HashMap<String,GtfsRealtime.TripUpdate> previousTripUpdates=new HashMap<String, TripUpdate>();    
+    		
     @Override
     public List<ErrorListHelperModel> validate(long currentTimeMillis, GtfsMutableDao gtfsData, GtfsMetadata gtfsMetadata, GtfsRealtime.FeedMessage feedMessage, GtfsRealtime.FeedMessage previousFeedMessage, GtfsRealtime.FeedMessage combinedFeedMessage) {
         List<OccurrenceModel> errorListE006 = new ArrayList<>();
         List<OccurrenceModel> errorListE013 = new ArrayList<>();
         List<OccurrenceModel> errorListW005 = new ArrayList<>();
+        List<OccurrenceModel> errorListE053 = new ArrayList<>();
 
         for (GtfsRealtime.FeedEntity entity : feedMessage.getEntityList()) {
             if (entity.hasTripUpdate()) {
                 GtfsRealtime.TripUpdate tripUpdate = entity.getTripUpdate();
+                
+           
 
                 if (gtfsMetadata.getExactTimesZeroTripIds().contains(tripUpdate.getTrip().getTripId())) {
                     /**
@@ -75,7 +83,25 @@ public class FrequencyTypeZeroValidator implements FeedEntityValidator {
                         // W005 - Missing vehicle_id in trip_update for frequency-based exact_times = 0
                         RuleUtils.addOccurrence(W005, "trip_id " + tripUpdate.getTrip().getTripId(), errorListW005, _log);
                     }
-                }
+                    
+                    if(tripUpdate.getVehicle()!=null && tripUpdate.getVehicle().getId()!=null && previousTripUpdates.get(tripUpdate.getVehicle().getId())!=null)
+                    {             
+                    	if(tripUpdate.getStopTimeUpdateCount()>0 && previousTripUpdates.get(tripUpdate.getVehicle().getId()).getStopTimeUpdateCount()>0)
+                    	{
+		                    if(tripUpdate.getStopTimeUpdate(tripUpdate.getStopTimeUpdateCount()-1).getStopSequence()>=previousTripUpdates.get(tripUpdate.getVehicle().getId()).getStopTimeUpdate(previousTripUpdates.get(tripUpdate.getVehicle().getId()).getStopTimeUpdateCount()-1).getStopSequence())
+		                    {
+		                    	 // E053 - start time of trip not consistent for trip updates for frequency-based exact_times = 0
+		                    	if(!tripUpdate.getTrip().getStartTime().equals(previousTripUpdates.get(tripUpdate.getVehicle().getId()).getTrip().getStartTime()))
+		                    	{
+		                    		RuleUtils.addOccurrence(E053, "vehicle_id" + tripUpdate.getVehicle().getId(),  errorListE053, _log);
+		                    	}		                    			                    	
+		                    }
+                    	}
+	                    
+                    }                                        	
+                }                
+                // Need to store previous for checking E053
+                previousTripUpdates.put(tripUpdate.getVehicle().getId(), tripUpdate);                                               
             }
 
             if (entity.hasVehicle()) {
@@ -118,6 +144,9 @@ public class FrequencyTypeZeroValidator implements FeedEntityValidator {
         }
         if (!errorListW005.isEmpty()) {
             errors.add(new ErrorListHelperModel(new MessageLogModel(W005), errorListW005));
+        }
+        if (!errorListE053.isEmpty()) {
+            errors.add(new ErrorListHelperModel(new MessageLogModel(E053), errorListE053));
         }
         return errors;
     }

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/FrequencyTypeZeroValidator.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/FrequencyTypeZeroValidator.java
@@ -82,30 +82,32 @@ public class FrequencyTypeZeroValidator implements FeedEntityValidator {
                         // W005 - Missing vehicle_id in trip_update for frequency-based exact_times = 0
                         RuleUtils.addOccurrence(W005, "trip_id " + tripUpdate.getTrip().getTripId(), errorListW005, _log);
                     }
-                    
-                    for (GtfsRealtime.FeedEntity previousEntity : previousFeedMessage.getEntityList()) 
-                    {                                        
-                    	if (previousEntity.hasTripUpdate()) 
-                    	{	
-                    		if(tripUpdate.getVehicle()!=null && previousEntity.getTripUpdate().getVehicle()!=null)
-                    		{                    				                    		
-	                    		if(previousEntity.getTripUpdate().getVehicle().getId().equals(tripUpdate.getVehicle().getId()))
-	                    		{				                               
-				                    if(tripUpdate.getStopTimeUpdateCount()>0 && previousEntity.getTripUpdate().getStopTimeUpdateCount()>0)
-				                    {				                    						                    		
-				                    	if(tripUpdate.getStopTimeUpdate(tripUpdate.getStopTimeUpdateCount()-1).getStopSequence()>=previousEntity.getTripUpdate().getStopTimeUpdate(previousEntity.getTripUpdate().getStopTimeUpdateCount()-1).getStopSequence())
-				                    	{
-						                    // E053 - start time of trip not consistent for trip updates for frequency-based exact_times = 0
-						                    if(!tripUpdate.getTrip().getStartTime().equals(previousEntity.getTripUpdate().getTrip().getStartTime()))
-						                    {
-						                    		RuleUtils.addOccurrence(E053, "vehicle_id " + tripUpdate.getVehicle().getId(),  errorListE053, _log);
-						                    }		                    			                    	
-				                    	}				                    						                  
-				                    }	                    		
+                    if(previousFeedMessage!=null)
+                    {
+	                    for (GtfsRealtime.FeedEntity previousEntity : previousFeedMessage.getEntityList()) 
+	                    {                                        
+	                    	if (previousEntity.hasTripUpdate()) 
+	                    	{	
+	                    		if(tripUpdate.getVehicle()!=null && previousEntity.getTripUpdate().getVehicle()!=null)
+	                    		{                    				                    		
+		                    		if(previousEntity.getTripUpdate().getVehicle().getId().equals(tripUpdate.getVehicle().getId()))
+		                    		{				                               
+					                    if(tripUpdate.getStopTimeUpdateCount()>0 && previousEntity.getTripUpdate().getStopTimeUpdateCount()>0)
+					                    {				                    						                    		
+					                    	if(tripUpdate.getStopTimeUpdate(tripUpdate.getStopTimeUpdateCount()-1).getStopSequence()>=previousEntity.getTripUpdate().getStopTimeUpdate(previousEntity.getTripUpdate().getStopTimeUpdateCount()-1).getStopSequence())
+					                    	{
+							                    // E053 - start time of trip not consistent for trip updates for frequency-based exact_times = 0
+							                    if(!tripUpdate.getTrip().getStartTime().equals(previousEntity.getTripUpdate().getTrip().getStartTime()))
+							                    {
+							                    		RuleUtils.addOccurrence(E053, "vehicle_id " + tripUpdate.getVehicle().getId(),  errorListE053, _log);
+							                    }		                    			                    	
+					                    	}				                    						                  
+					                    }	                    		
+		                    		}
 	                    		}
-                    		}
-                    	}
-                    }                                                               
+	                    	}
+	                    }
+                    }
                 }
             }
             if (entity.hasVehicle()) {

--- a/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/UtilTest.java
+++ b/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/UtilTest.java
@@ -844,6 +844,6 @@ public class UtilTest {
     @Test
     public void testGetAllRules() {
         List<ValidationRule> rules = ValidationRules.getRules();
-        assertEquals(61, rules.size());
+        assertEquals(62, rules.size());
     }
 }

--- a/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/FrequencyTypeZeroValidatorTest.java
+++ b/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/FrequencyTypeZeroValidatorTest.java
@@ -1,6 +1,8 @@
 package edu.usf.cutr.gtfsrtvalidator.lib.test.rules;
 
 import com.google.transit.realtime.GtfsRealtime;
+import com.google.transit.realtime.GtfsRealtime.FeedMessage;
+
 import edu.usf.cutr.gtfsrtvalidator.lib.model.ValidationRule;
 import edu.usf.cutr.gtfsrtvalidator.lib.test.FeedMessageTest;
 import edu.usf.cutr.gtfsrtvalidator.lib.test.util.TestUtils;
@@ -270,7 +272,7 @@ public class FrequencyTypeZeroValidatorTest extends FeedMessageTest {
     {
     	FrequencyTypeZeroValidator frequencyTypeZeroValidator = new FrequencyTypeZeroValidator();
         Map<ValidationRule, Integer> expected = new HashMap<>();
-        
+        FeedMessage[] feedMessages= new FeedMessage[2];
         for( int i = 0; i <2;i++)
         {
 	        GtfsRealtime.TripDescriptor.Builder tripDescriptorBuilder = GtfsRealtime.TripDescriptor.newBuilder();
@@ -315,23 +317,22 @@ public class FrequencyTypeZeroValidatorTest extends FeedMessageTest {
 		                
 		        tripUpdateBuilder.addStopTimeUpdate(stopTimeUpdateBuilder.build());
 	        }
-	        
-	        
+	        	       
 	        feedEntityBuilder.setTripUpdate(tripUpdateBuilder.build());
 	        
 	        // Add vehicle_id to vehicle position - 1 warning        
 	        feedEntityBuilder.setVehicle(vehiclePositionBuilder.build());
-	
-	
+		
 	        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
 	        	        
-	        results = frequencyTypeZeroValidator.validate(TimestampUtils.MIN_POSIX_TIME, bullRunnerGtfs, bullRunnerGtfsMetadata, feedMessageBuilder.build(), null, null);
-	        	        	        	        	        	            	        
-	      
+	        feedMessages[i]=feedMessageBuilder.build();
+	        
+	        	        	        	        	        	            	       	      
         }
+        results = frequencyTypeZeroValidator.validate(TimestampUtils.MIN_POSIX_TIME, bullRunnerGtfs, bullRunnerGtfsMetadata, feedMessages[1], feedMessages[0], null);
         expected.put(ValidationRules.E053, 1);
         TestUtils.assertResults(expected, results);
-
+        expected.clear();
         clearAndInitRequiredFeedFields();        
     }
 }

--- a/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/FrequencyTypeZeroValidatorTest.java
+++ b/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/FrequencyTypeZeroValidatorTest.java
@@ -262,4 +262,76 @@ public class FrequencyTypeZeroValidatorTest extends FeedMessageTest {
 
         clearAndInitRequiredFeedFields();
     }
+    /**
+     * E053- inconsistent start time in trip descriptor for frequency-based exact_times = 0
+     */
+    @Test
+    public void testE053()
+    {
+    	FrequencyTypeZeroValidator frequencyTypeZeroValidator = new FrequencyTypeZeroValidator();
+        Map<ValidationRule, Integer> expected = new HashMap<>();
+        
+        for( int i = 0; i <2;i++)
+        {
+	        GtfsRealtime.TripDescriptor.Builder tripDescriptorBuilder = GtfsRealtime.TripDescriptor.newBuilder();
+	        
+	        tripDescriptorBuilder.setTripId("1");
+	        tripDescriptorBuilder.setStartDate("4-24-2016");
+	        if(i==0)
+	        {
+	        	tripDescriptorBuilder.setStartTime("08:00:00AM");
+	        }
+	        if(i==1)
+	        {
+	        	tripDescriptorBuilder.setStartTime("09:00:00AM");
+	        }
+	        	       
+	        
+	        GtfsRealtime.VehicleDescriptor.Builder vehicleDescriptorBuilder = GtfsRealtime.VehicleDescriptor.newBuilder();
+	                
+	        vehicleDescriptorBuilder.setId("1");
+	        
+	        vehiclePositionBuilder.setVehicle(vehicleDescriptorBuilder.build());
+	        vehiclePositionBuilder.setTimestamp(TimestampUtils.MIN_POSIX_TIME);
+	        vehiclePositionBuilder.setTrip(tripDescriptorBuilder.build());
+	        vehiclePositionBuilder.setVehicle(vehicleDescriptorBuilder.build());
+	                                
+	        feedEntityBuilder.setVehicle(vehiclePositionBuilder.build());
+	
+	        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+	        
+	        tripUpdateBuilder.setVehicle(vehicleDescriptorBuilder.build());
+	        tripUpdateBuilder.setTrip(tripDescriptorBuilder.build());
+	        
+	        for(int j=0;j<i+1;j++)
+	        {
+		        GtfsRealtime.TripUpdate.StopTimeUpdate.Builder stopTimeUpdateBuilder = GtfsRealtime.TripUpdate.StopTimeUpdate.newBuilder();
+		        	        
+		        stopTimeUpdateBuilder.setStopId(""+j);
+		        stopTimeUpdateBuilder.setStopSequence(j);
+		        
+		        GtfsRealtime.TripUpdate.StopTimeEvent.Builder stopTimeEventBuilder =  GtfsRealtime.TripUpdate.StopTimeEvent.newBuilder();  
+		        stopTimeUpdateBuilder.setArrival(stopTimeEventBuilder.build());
+		                
+		        tripUpdateBuilder.addStopTimeUpdate(stopTimeUpdateBuilder.build());
+	        }
+	        
+	        
+	        feedEntityBuilder.setTripUpdate(tripUpdateBuilder.build());
+	        
+	        // Add vehicle_id to vehicle position - 1 warning        
+	        feedEntityBuilder.setVehicle(vehiclePositionBuilder.build());
+	
+	
+	        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+	        	        
+	        results = frequencyTypeZeroValidator.validate(TimestampUtils.MIN_POSIX_TIME, bullRunnerGtfs, bullRunnerGtfsMetadata, feedMessageBuilder.build(), null, null);
+	        	        	        	        	        	            	        
+	      
+        }
+        expected.put(ValidationRules.E053, 1);
+        TestUtils.assertResults(expected, results);
+
+        clearAndInitRequiredFeedFields();        
+    }
 }


### PR DESCRIPTION
**Summary:**
This is to add the rule detailed in issue #154 

**Expected behavior:** 
It should record an E053 error if the start time for a trip does not stay the same between updates.

It looks for the latest stop sequence in the respective (previous/current) trip updates for a vehicle and if the current one is the same or after the previous one it then checks that the start time is the same. If they are not the same it raises an E053 error.
