### PR TITLE
Fix #349 - Set Locale.US for TimestampUtils' mDecimalFormatLocal

### DIFF
--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/util/TimestampUtils.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/util/TimestampUtils.java
@@ -20,12 +20,14 @@ import org.apache.commons.io.FilenameUtils;
 
 import java.text.DateFormat;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.util.Locale;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
@@ -44,7 +46,8 @@ public class TimestampUtils {
             .parseCaseInsensitive().appendPattern(dateFormat).toFormatter();
     private static ThreadLocal<DateFormat> mTimeFormatTLocal = ThreadLocal.withInitial(() -> new SimpleDateFormat(timeFormat));
     private static Pattern mTimePattern = Pattern.compile("^[0-2][0-9]:[0-5][0-9]:[0-5][0-9]$"); // Up to 29 hrs
-    private static ThreadLocal<DecimalFormat> mDecimalFormatTLocal= ThreadLocal.withInitial(() -> new DecimalFormat("0.0##"));
+    private static ThreadLocal<DecimalFormat> mDecimalFormatTLocal= ThreadLocal.withInitial(() -> new DecimalFormat("0.0##",
+            new DecimalFormatSymbols(Locale.US)));
 
     /**
      * Returns true if the timestamp is a valid POSIX time, false if it is not


### PR DESCRIPTION
**Summary:**

This PR pins the Locale used for decimal formatting to Locale.US to fix #349.

**Expected behavior:** 

mvn test now succeeds on German locale. Numbers are formatted with "." as decimal separator.
<img width="565" alt="image" src="https://user-images.githubusercontent.com/2187389/59656329-86dc7a80-919d-11e9-9b06-5c993627f55f.png">



Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Run the unit tests with `mvn test` to make sure you didn't break anything
- [X] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)