### PR TITLE
Fix #352 - close protobuf files opened by batch processor

### DIFF
--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/batch/BatchProcessor.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/batch/BatchProcessor.java
@@ -198,7 +198,9 @@ public class BatchProcessor {
             long startToByteArray = System.nanoTime();
             byte[] protobuf;
             try {
-                protobuf = IOUtils.toByteArray(Files.newInputStream(path));
+            	InputStream inputStream = Files.newInputStream(path);
+                protobuf = IOUtils.toByteArray(inputStream);
+                inputStream.close();
             } catch (IOException e) {
                 _log.error("Error reading GTFS-rt file to byte array, skipping to next file: " + e);
                 continue;


### PR DESCRIPTION
Issue #352 

**Summary:**

Protobuf files being read by BatchProcessor are never closed.

**Expected behavior:** 

Protobuf files opened and read by BatchProcessor will close after being read, thus removing the filesystem lock preventing deletion and other operations.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x ] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s) [skipped, should be self-explanatory.)
