### PR TITLE
Fix #352 close input streams on protobuf file reads.

### DIFF
--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/batch/BatchProcessor.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/batch/BatchProcessor.java
@@ -198,7 +198,9 @@ public class BatchProcessor {
             long startToByteArray = System.nanoTime();
             byte[] protobuf;
             try {
-                protobuf = IOUtils.toByteArray(Files.newInputStream(path));
+            	InputStream inputStream = Files.newInputStream(path);
+                protobuf = IOUtils.toByteArray(inputStream);
+                inputStream.close();
             } catch (IOException e) {
                 _log.error("Error reading GTFS-rt file to byte array, skipping to next file: " + e);
                 continue;

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewFeedMessageModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewFeedMessageModel.java
@@ -65,6 +65,7 @@ public class ViewFeedMessageModel {
         GtfsRealtime.FeedMessage feedMessage = null;
         try {
             feedMessage = GtfsRealtime.FeedMessage.parseFrom(is);
+        	is.close();
         } catch (IOException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
**Summary:**

Fix #352 Protobuf files being read by the batch processor never get closed.

**Expected behavior:** 

Protobuf files being read by the batch processor will be properly closed. My apologies @barbeau, but I jumped the gun on the earlier commit for this issue. ViewFeedMessageModel's input stream was not being closed and needed to be addressed.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x ] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x ] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
