### PR TITLE
Add javax.xml.bind as dependencies for Java 11 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: java
 jdk:
  - oraclejdk8
  - openjdk8
+ - openjdk11
 
 cache:
   directories:

--- a/gtfs-realtime-validator-lib/pom.xml
+++ b/gtfs-realtime-validator-lib/pom.xml
@@ -25,6 +25,28 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.9.8</version>
         </dependency>
+        <!-- starting with Java 11 these libraries are no longer part of the JRE by default
+             therefore they have to be added as ordinary dependencies -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
         <!-- GTFS-to-Java objects -->
         <dependency>
             <groupId>org.onebusaway</groupId>
@@ -120,7 +142,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.20.1</version>
+                <version>3.0.0-M3</version>
                 <configuration>
                     <includes>
                         <include>**/*Spec.*</include>

--- a/gtfs-realtime-validator-webapp/pom.xml
+++ b/gtfs-realtime-validator-webapp/pom.xml
@@ -169,7 +169,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.20.1</version>
+                <version>3.0.0-M3</version>
                 <configuration>
                     <includes>
                         <include>**/*Spec.*</include>


### PR DESCRIPTION
**Summary:**

The JAR file is not runnable with Java 11 as java.xml.bind is no longer part of the JRE and has to be added by the build.

In https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/312#issuecomment-473732768 you've asked if this will still work with Java 8. Yes it will. To ensure this the tests are run with both Java 8 and 11.

Additionally, I had to bump the surefire version to make the tests run on Java 11.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [ ] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
