### PR TITLE
Update README to reflect the compatibility with Java 9,10,11 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Questions? You can [open an issue](https://github.com/CUTR-at-USF/gtfs-realtime-
 1. Download the latest webapp alpha build:
     * [gtfs-realtime-validator-webapp-1.0.0-SNAPSHOT.jar](https://s3.amazonaws.com/gtfs-rt-validator/travis_builds/gtfs-realtime-validator-webapp/1.0.0-SNAPSHOT/gtfs-realtime-validator-webapp-1.0.0-SNAPSHOT.jar)
 1. From the command line run `java -Djsse.enableSNIExtension=false -jar gtfs-realtime-validator-webapp-1.0.0-SNAPSHOT.jar`
-    * Note that if you're running on Java 9, you'll need to instead run `java -Djsee.enableSNIExtension=false --add-modules java.xml.bind -jar gtfs-realtime-validator-webapp/target/gtfs-realtime-validator-webapp-1.0.0-SNAPSHOT.jar`
 1. When prompted, in your browser go to `http://localhost:8080`
 1. Enter your [General Transit Feed Specification (GTFS)-realtime](https://developers.google.com/transit/gtfs-realtime/) and [GTFS](https://developers.google.com/transit/gtfs/) feed URLs and click "Start".  Example feeds:
     * HART (Tampa, FL)
@@ -81,9 +80,8 @@ If you're going to be rebuilding the project frequently (e.g., editing source co
 
 To start up the server so you can view the web interface, from the command-line, run: 
 
-* *Java 8 and lower*: `java -Djsse.enableSNIExtension=false -jar gtfs-realtime-validator-webapp/target/gtfs-realtime-validator-webapp-1.0.0-SNAPSHOT.jar`
+* `java -Djsse.enableSNIExtension=false -jar gtfs-realtime-validator-webapp/target/gtfs-realtime-validator-webapp-1.0.0-SNAPSHOT.jar`
 
-* *Java 9 and above*: `java -Djsee.enableSNIExtension=false --add-modules java.xml.bind -jar gtfs-realtime-validator-webapp/target/gtfs-realtime-validator-webapp-1.0.0-SNAPSHOT.jar`
 
 You should see some output, and a message saying `Go to http://localhost:8080 in your browser`.
 

--- a/gtfs-realtime-validator-lib/pom.xml
+++ b/gtfs-realtime-validator-lib/pom.xml
@@ -42,11 +42,6 @@
             <artifactId>jaxb-runtime</artifactId>
             <version>2.3.0</version>
         </dependency>
-        <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-            <version>1.1.1</version>
-        </dependency>
         <!-- GTFS-to-Java objects -->
         <dependency>
             <groupId>org.onebusaway</groupId>


### PR DESCRIPTION
As discussed previously.

Turns out that the activation jar was not needed.