### PR TITLE
Fix #351 - Added logging for failed GTFS load from disk

### DIFF
--- a/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsFeed.java
+++ b/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsFeed.java
@@ -285,6 +285,7 @@ public class GtfsFeed {
             reader.setEntityStore(store);
             reader.run();
         } catch (Exception ex) {
+            Logger.getLogger(GtfsFeed.class.getName()).log(Level.SEVERE, null, ex);
             return null;
         }
         return store;


### PR DESCRIPTION
**Summary:**

Logs an exception when the GTFS file fails to load from disk. This covers a wide range of GTFS parsing/loading errors.

**Expected behavior:** 

Explain and/or show screenshots for how you expect the pull request to work in your testing (in case other devices exhibit different behavior).

Exceptions are logged to the console. Requested as an aside in #374 by @derhuerst.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Run the unit tests with `mvn test` to make sure you didn't break anything
- [X] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)
