### PR TITLE
Dockerfile: move java args to entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN mvn package
 
 FROM openjdk:8-alpine AS final
 EXPOSE 8080
-ENTRYPOINT ["java"]
-CMD ["-Djsee.enableSNIExtension=false", "-jar", "gtfs-realtime-validator-webapp-1.0.0-SNAPSHOT.jar"]
+ENTRYPOINT ["java", "-Djsee.enableSNIExtension=false", "-jar", "gtfs-realtime-validator-webapp-1.0.0-SNAPSHOT.jar"]
+CMD []
 WORKDIR /app
 COPY --from=build /build/gtfs-realtime-validator-webapp/target/ .


### PR DESCRIPTION
see https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/374#issuecomment-599615009

This PR adapts the Dockerfile introduced in #375: I moved the args to be provided to the `java` executable from `CMD` to `ENTRYPOINT`. This should allow me to provide additional `java` options/flags easily.

FYI: I haven't tested this locally.