### PR TITLE
fix: Update OBA and Geotools mvn repos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,19 @@
 
     <repositories>
         <repository>
+            <id>osgeo</id>
+            <name>OSGeo Release Repository</name>
+            <url>https://repo.osgeo.org/repository/release/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+        <repository>
             <id>public.onebusaway.org</id>
-            <url>http://nexus.onebusaway.org/content/groups/public/</url>
+            <url>https://repo.camsys-apps.com/releases/</url>
         </repository>
     </repositories>
 </project>


### PR DESCRIPTION
**Summary:**

Update OBA and Geotools mvn repos. Build appears to be failing due to missing Geotools dependencies - see https://github.com/CUTR-at-USF/gtfs-realtime-validator/pull/380.

**Expected behavior:** 

Builds should succeed