### PR TITLE
fix: Allow HTTP connnection to Conveyal Maven repo

### DIFF
--- a/.mvn/custom-settings.xml
+++ b/.mvn/custom-settings.xml
@@ -1,0 +1,21 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 http://maven.apache.org/xsd/settings-1.2.0.xsd">
+    <!-- This file should be removed, along with maven.config, when the Conveyal GTFS validator dependency is removed. -->
+    <mirrors>
+        <mirror>
+            <id>conveyal-snapshots-mvn-repo-mirror</id>
+            <mirrorOf>conveyal-snapshots-mvn-repo</mirrorOf>
+            <name>Snapshots build.staging.obanyc.com</name>
+            <url>http://build.staging.obanyc.com/archiva/repository/snapshots/</url>
+            <blocked>false</blocked>
+        </mirror>
+		<mirror>
+            <id>conveyal-releases-mvn-repo-mirror</id>
+            <mirrorOf>conveyal-releases-mvn-repo</mirrorOf>
+            <name>Releases build.staging.obanyc.com</name>
+            <url>http://build.staging.obanyc.com/archiva/repository/releases/</url>
+            <blocked>false</blocked>
+        </mirror>
+    </mirrors>
+</settings>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+--settings ./.mvn/custom-settings.xml


### PR DESCRIPTION
**Summary:**

This Maven configuration allows Maven to use HTTP for connection to the Conveyal Maven repo. These files can be removed when the transition to the MobilityData gtfs-validator is complete (https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/193).

Closes https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/399

**Expected behavior:** 

Build should succeed instead of fail.
